### PR TITLE
Add error checking for calling CreateVariations with no variants

### DIFF
--- a/context.go
+++ b/context.go
@@ -718,6 +718,11 @@ func (c *Context) processSubdirs(
 func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 	variationNames []string) ([]*moduleInfo, []error) {
 
+	if len(variationNames) == 0 {
+		panic(fmt.Errorf("mutator %q passed zero-length variation list for module %q",
+				mutatorName, origModule.properties.Name))
+	}
+
 	newModules := []*moduleInfo{}
 
 	var errs []error


### PR DESCRIPTION
Calling CreateVariations with no variants will corrupt the
modules list with a module with nil logicModule, panic early
with a useful message instead.

Change-Id: Ic5c921efcba70c54efb5bb21a9626b2999376a69