### PR TITLE
Fix cycle printing

### DIFF
--- a/context.go
+++ b/context.go
@@ -1177,7 +1177,7 @@ func (c *Context) updateDependencies() (errs []error) {
 		})
 
 		// Iterate backwards through the cycle list.
-		curModule := cycle[len(cycle)-1]
+		curModule := cycle[0]
 		for i := len(cycle) - 1; i >= 0; i-- {
 			nextModule := cycle[i]
 			errs = append(errs, &Error{


### PR DESCRIPTION
The patch "Fix panic when dependency cycle includes the first
module visited" caused cycles to print incorrectly by initializing
the current module to be the last module in the cycle, when it
should be the first module in the cycle.

Change-Id: Iaf939283a48faa4cc6eeb9b19aed57993575a687