### PR TITLE
Indent code block in doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -35,17 +35,17 @@
 // the module type looks like a function call, and the properties of the module
 // look like optional arguments.  For example, a simple module might look like:
 //
-// cc_library(
-//     name = "cmd",
-//     srcs = [
-//         "main.c",
-//     ],
-//     deps = [
-//         "libc",
-//     ],
-// )
+//   cc_library(
+//       name = "cmd",
+//       srcs = [
+//           "main.c",
+//       ],
+//       deps = [
+//           "libc",
+//       ],
+//   )
 //
-// subdirs = ["subdir1", "subdir2"]
+//   subdirs = ["subdir1", "subdir2"]
 //
 // The modules from the top level Blueprints file and recursively through any
 // subdirectories listed by the "subdirs" variable are read by Blueprint, and


### PR DESCRIPTION
This fixes the Godoc HTML rendering, swapping this:
![image](https://cloud.githubusercontent.com/assets/2149341/7102312/f0d1861a-e030-11e4-900d-6dab1ba4a561.png)

for this:

![image](https://cloud.githubusercontent.com/assets/2149341/7102319/0f7dbe12-e031-11e4-9d71-d0e7ca4d761c.png)

