### PR TITLE
Adding a builtinPool type

### DIFF
--- a/live_tracker.go
+++ b/live_tracker.go
@@ -113,6 +113,10 @@ func (l *liveTracker) addPool(p Pool) error {
 	_, ok := l.pools[p]
 	if !ok {
 		def, err := p.def(l.config)
+		if err == errPoolIsBuiltin {
+			// No need to do anything for built-in rules.
+			return nil
+		}
 		if err != nil {
 			return err
 		}

--- a/package_ctx.go
+++ b/package_ctx.go
@@ -98,7 +98,12 @@ var Phony Rule = &builtinRule{
 	name_: "phony",
 }
 
+var Console Pool = &builtinPool{
+	name_: "console",
+}
+
 var errRuleIsBuiltin = errors.New("the rule is a built-in")
+var errPoolIsBuiltin = errors.New("the pool is a built-in")
 var errVariableIsArg = errors.New("argument variables have no value")
 
 // checkCalledFromInit panics if a Go package's init function is not on the
@@ -555,6 +560,30 @@ func (p *poolFunc) def(config interface{}) (*poolDef, error) {
 
 func (p *poolFunc) String() string {
 	return p.pctx.pkgPath + "." + p.name_
+}
+
+type builtinPool struct {
+	name_  string
+}
+
+func (p *builtinPool) packageContext() *PackageContext {
+	return nil
+}
+
+func (p *builtinPool) name() string {
+	return p.name_
+}
+
+func (p *builtinPool) fullName(pkgNames map[*PackageContext]string) string {
+	return p.name_
+}
+
+func (p *builtinPool) def(config interface{}) (*poolDef, error) {
+	return nil, errPoolIsBuiltin
+}
+
+func (p *builtinPool) String() string {
+	return "<builtin>:" + p.name_
 }
 
 type staticRule struct {

--- a/scope.go
+++ b/scope.go
@@ -170,6 +170,11 @@ func (s *basicScope) IsRuleVisible(rule Rule) bool {
 }
 
 func (s *basicScope) IsPoolVisible(pool Pool) bool {
+	_, isBuiltin := pool.(*builtinPool)
+	if isBuiltin {
+		return true
+	}
+
 	name := pool.name()
 
 	for s != nil {


### PR DESCRIPTION
This implements the Pool interface. An instance of a builtinPool
is created for the Console pool.

Change-Id: I03334c25495dc573aef2c0e62415352a0b10d6fd