### PR TITLE
Add bpfind tool

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -80,6 +80,12 @@ bootstrap_go_binary(
 )
 
 bootstrap_go_binary(
+    name = "bpfind",
+    deps = ["blueprint"],
+    srcs = ["bpfind/bpfind.go"],
+)
+
+bootstrap_go_binary(
     name = "bpfmt",
     deps = ["blueprint-parser"],
     srcs = ["bpfmt/bpfmt.go"],

--- a/bpfind/bpfind.go
+++ b/bpfind/bpfind.go
@@ -9,6 +9,13 @@ import (
 	"github.com/google/blueprint"
 )
 
+// TODO: implement, need to set a variable in the top-level scope
+// This would let you start from a directory that isn't the root directory
+//var subname = flag.String("subname", "Android.bp", "Default subname")
+
+var name = flag.String("name", "", "Only print blueprints with this file name")
+var without = flag.String("without", "", "Only print blueprints without this file in the same directory")
+
 func main() {
 	flag.Parse()
 
@@ -28,6 +35,15 @@ func main() {
 	}
 
 	for _, file := range blueprints {
+		if *name != "" && filepath.Base(file) != *name {
+			continue
+		}
+		if *without != "" {
+			_, err := os.Stat(filepath.Join(filepath.Dir(file), *without))
+			if !os.IsNotExist(err) {
+				continue
+			}
+		}
 		fmt.Println(file)
 	}
 }

--- a/bpfind/bpfind.go
+++ b/bpfind/bpfind.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/blueprint"
+)
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "No filename supplied\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	ctx := blueprint.NewContext()
+	ctx.SetIgnoreUnknownModuleTypes(true)
+	blueprints, errs := ctx.FindBlueprintsFiles(flag.Arg(0))
+	if len(errs) > 0 {
+		fmt.Fprintf(os.Stderr, "%d errors parsing %s\n", len(errs), flag.Arg(0))
+		fmt.Fprintln(os.Stderr, errs)
+		os.Exit(1)
+	}
+
+	for _, file := range blueprints {
+		fmt.Println(file)
+	}
+}

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -155,11 +155,36 @@ default $
         .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Module:  bpfmt
+# Module:  bpfind
 # Variant:
 # Type:    bootstrap_go_binary
 # Factory: github.com/google/blueprint/bootstrap.newGoBinaryModule
 # Defined: Blueprints:82:1
+
+build .bootstrap/bpfind/obj/bpfind.a: g.bootstrap.gc $
+        ${g.bootstrap.srcDir}/bpfind/bpfind.go | ${g.bootstrap.gcCmd} $
+        .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
+        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
+        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
+        .bootstrap/blueprint/pkg/github.com/google/blueprint.a
+    incFlags = -I .bootstrap/blueprint-parser/pkg -I .bootstrap/blueprint-pathtools/pkg -I .bootstrap/blueprint-proptools/pkg -I .bootstrap/blueprint/pkg
+    pkgPath = bpfind
+default .bootstrap/bpfind/obj/bpfind.a
+
+build .bootstrap/bpfind/obj/a.out: g.bootstrap.link $
+        .bootstrap/bpfind/obj/bpfind.a | ${g.bootstrap.linkCmd}
+    libDirFlags = -L .bootstrap/blueprint-parser/pkg -L .bootstrap/blueprint-pathtools/pkg -L .bootstrap/blueprint-proptools/pkg -L .bootstrap/blueprint/pkg
+default .bootstrap/bpfind/obj/a.out
+
+build .bootstrap/bin/bpfind: g.bootstrap.cp .bootstrap/bpfind/obj/a.out
+default .bootstrap/bin/bpfind
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Module:  bpfmt
+# Variant:
+# Type:    bootstrap_go_binary
+# Factory: github.com/google/blueprint/bootstrap.newGoBinaryModule
+# Defined: Blueprints:88:1
 
 build .bootstrap/bpfmt/obj/bpfmt.a: g.bootstrap.gc $
         ${g.bootstrap.srcDir}/bpfmt/bpfmt.go | ${g.bootstrap.gcCmd} $
@@ -181,7 +206,7 @@ default .bootstrap/bin/bpfmt
 # Variant:
 # Type:    bootstrap_go_binary
 # Factory: github.com/google/blueprint/bootstrap.newGoBinaryModule
-# Defined: Blueprints:88:1
+# Defined: Blueprints:94:1
 
 build .bootstrap/bpmodify/obj/bpmodify.a: g.bootstrap.gc $
         ${g.bootstrap.srcDir}/bpmodify/bpmodify.go | ${g.bootstrap.gcCmd} $
@@ -241,8 +266,8 @@ rule s.bootstrap.minibp
     generator = true
 
 build .bootstrap/main.ninja.in: s.bootstrap.bigbp $
-        ${g.bootstrap.srcDir}/Blueprints | .bootstrap/bin/bpfmt $
-        .bootstrap/bin/bpmodify .bootstrap/bin/minibp
+        ${g.bootstrap.srcDir}/Blueprints | .bootstrap/bin/bpfind $
+        .bootstrap/bin/bpfmt .bootstrap/bin/bpmodify .bootstrap/bin/minibp
 default .bootstrap/main.ninja.in
 build .bootstrap/notAFile: phony
 default .bootstrap/notAFile


### PR DESCRIPTION
Blueprint files aren't necessarily called 'Blueprints' anymore, with the use of subname= and build=. Add a tool that can print a list of parsed blueprints.