### PR TITLE
Fix glob dependencies when initial non-wild path does not exist

### DIFF
--- a/pathtools/glob_test.go
+++ b/pathtools/glob_test.go
@@ -334,6 +334,58 @@ var globTestCases = []struct {
 		dirs:     []string{"c", "c/f", "c/g", "c/h"},
 	},
 
+	// non-existant non-wild path tests
+	{
+		pattern: "d/*",
+		matches: nil,
+		dirs:    []string{"."},
+	},
+	{
+		pattern: "d",
+		matches: nil,
+		dirs:    []string{"."},
+	},
+	{
+		pattern: "a/d/*",
+		matches: nil,
+		dirs:    []string{"a"},
+	},
+	{
+		pattern: "a/d",
+		matches: nil,
+		dirs:    []string{"a"},
+	},
+	{
+		pattern: "a/a/d/*",
+		matches: nil,
+		dirs:    []string{"a/a"},
+	},
+	{
+		pattern: "a/a/d",
+		matches: nil,
+		dirs:    []string{"a/a"},
+	},
+	{
+		pattern: "a/d/a/*",
+		matches: nil,
+		dirs:    []string{"a"},
+	},
+	{
+		pattern: "a/d/a",
+		matches: nil,
+		dirs:    []string{"a"},
+	},
+	{
+		pattern: "a/d/a/*/a",
+		matches: nil,
+		dirs:    []string{"a"},
+	},
+	{
+		pattern: "a/d/a/**/a",
+		matches: nil,
+		dirs:    []string{"a"},
+	},
+
 	// recursive exclude error tests
 	{
 		pattern:  "**/*",


### PR DESCRIPTION
If the initial non-wild part of a glob path does not exist, return
the last existing part of the path as a dependency to detect if the
path is created later.

Change-Id: Ib5a39e6830cb386deed26e017279d0aac1bc9a20