### PR TITLE
Fix a sub-Blueprints deps bug.

### DIFF
--- a/context.go
+++ b/context.go
@@ -743,7 +743,7 @@ func (c *Context) findSubdirBlueprints(dir string, subdirs, build []string, subB
 				// need to add the directory to the list of dependencies
 				// so that if someone adds a Blueprints file in the
 				// future we'll pick it up.
-				deps = append(deps, filepath.Dir(foundSubdir))
+				deps = append(deps, foundSubdir)
 			} else {
 				deps = append(deps, subBlueprints)
 				blueprints = append(blueprints, subBlueprints)


### PR DESCRIPTION
This change fixes a bug where directories that could contain a Blueprints file
but currently do not were not being added as a dependency.  This meant that if
a Blueprints file were added to that directory it would not automatically get
picked up by the build.