### PR TITLE
Add option to run bootstrap.Main, but not write the ninja file

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -50,7 +50,7 @@ func init() {
 	flag.BoolVar(&runGoTests, "t", false, "build and run go tests during bootstrap")
 }
 
-func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...string) {
+func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...string) []string {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
@@ -67,7 +67,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		defer pprof.StopCPUProfile()
 	}
 
-	if flag.NArg() != 1 {
+	if flag.NArg() < 1 {
 		fatalf("no Blueprints file specified")
 	}
 
@@ -111,7 +111,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		if err != nil {
 			fatalErrors([]error{err})
 		}
-		return
+		return []string{}
 	}
 
 	extraDeps, errs := ctx.PrepareBuildActions(config)
@@ -119,6 +119,12 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		fatalErrors(errs)
 	}
 	deps = append(deps, extraDeps...)
+
+	if c, ok := config.(ConfigInterface2); ok {
+		if !c.CreateNinjaFile() {
+			return deps
+		}
+	}
 
 	buf := bytes.NewBuffer(nil)
 	err := ctx.WriteBuildFile(buf)
@@ -162,6 +168,8 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	if err != nil {
 		fatalf("error removing abandoned files: %s", err)
 	}
+
+	return []string{}
 }
 
 func fatalf(format string, args ...interface{}) {

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -41,6 +41,13 @@ type ConfigInterface interface {
 	GeneratingPrimaryBuilder() bool
 }
 
+type ConfigInterface2 interface {
+	// CreateNinjaFile should return true if this build invocation is creating
+	// a build.ninja file. Otherwise, only parsing and dependency evaluation
+	// will happen.
+	CreateNinjaFile() bool
+}
+
 type Stage int
 
 const (


### PR DESCRIPTION
So that everything is evaluated, but we don't actually write out the
ninja file. This is intended for use by tools to inspect modules that
have been fully created.
