### PR TITLE
Support a separate build directory

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -100,8 +100,8 @@ var (
 		},
 		"depfile")
 
-	BinDir     = filepath.Join(bootstrapDir, "bin")
-	minibpFile = filepath.Join(BinDir, "minibp")
+	binDir     = pctx.StaticVariable("BinDir", filepath.Join(bootstrapDir, "bin"))
+	minibpFile = filepath.Join("$BinDir", "minibp")
 
 	docsDir = filepath.Join(bootstrapDir, "docs")
 )
@@ -296,7 +296,7 @@ func (g *goBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 		objDir      = moduleObjDir(ctx)
 		archiveFile = filepath.Join(objDir, name+".a")
 		aoutFile    = filepath.Join(objDir, "a.out")
-		binaryFile  = filepath.Join(BinDir, name)
+		binaryFile  = filepath.Join("$BinDir", name)
 	)
 
 	if len(g.properties.TestSrcs) > 0 && g.config.runGoTests {
@@ -531,7 +531,7 @@ func (s *singleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 		func(module blueprint.Module) {
 			binaryModule := module.(*goBinary)
 			binaryModuleName := ctx.ModuleName(binaryModule)
-			binaryModulePath := filepath.Join(BinDir, binaryModuleName)
+			binaryModulePath := filepath.Join("$BinDir", binaryModuleName)
 
 			if binaryModule.BuildStage() == StageBootstrap {
 				rebootstrapDeps = append(rebootstrapDeps, binaryModulePath)
@@ -564,7 +564,7 @@ func (s *singleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 		return
 	}
 
-	primaryBuilderFile := filepath.Join(BinDir, primaryBuilderName)
+	primaryBuilderFile := filepath.Join("$BinDir", primaryBuilderName)
 
 	if s.config.runGoTests {
 		primaryBuilderExtraFlags += " -t"

--- a/bootstrap/cleanup.go
+++ b/bootstrap/cleanup.go
@@ -47,11 +47,12 @@ func removeAbandonedFiles(ctx *blueprint.Context, config *Config,
 
 	replacer := strings.NewReplacer(
 		"@@SrcDir@@", srcDir,
+		"@@BuildDir@@", BuildDir,
 		"@@BootstrapManifest@@", manifestFile)
 	targets := make(map[string]bool)
 	for target := range targetRules {
 		replacedTarget := replacer.Replace(target)
-		targets[replacedTarget] = true
+		targets[filepath.Clean(replacedTarget)] = true
 	}
 
 	filePaths, err := parseNinjaLog(buildDir)

--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -37,10 +37,13 @@ var (
 	docFile          string
 	cpuprofile       string
 	runGoTests       bool
+
+	BuildDir string
 )
 
 func init() {
 	flag.StringVar(&outFile, "o", "build.ninja.in", "the Ninja file to output")
+	flag.StringVar(&BuildDir, "b", ".", "the build output directory")
 	flag.StringVar(&depFile, "d", "", "the dependency file to output")
 	flag.StringVar(&timestampFile, "timestamp", "", "file to write before the output file")
 	flag.StringVar(&timestampDepFile, "timestampdep", "", "the dependency file for the timestamp file")

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -19,6 +19,7 @@ var (
 	// modules.  They are always set to the variable name enclosed in "@@" so
 	// that their values can be easily replaced in the generated Ninja file.
 	srcDir            = pctx.StaticVariable("srcDir", "@@SrcDir@@")
+	buildDir          = pctx.StaticVariable("buildDir", "@@BuildDir@@")
 	goRoot            = pctx.StaticVariable("goRoot", "@@GoRoot@@")
 	goOS              = pctx.StaticVariable("goOS", "@@GoOS@@")
 	goArch            = pctx.StaticVariable("goArch", "@@GoArch@@")

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -9,13 +9,15 @@
 #
 ninja_required_version = 1.6.0
 
-g.bootstrap.BinDir = .bootstrap/bin
+g.bootstrap.buildDir = @@BuildDir@@
+
+g.bootstrap.BinDir = ${g.bootstrap.buildDir}/.bootstrap/bin
 
 g.bootstrap.bootstrapCmd = @@Bootstrap@@
 
 g.bootstrap.bootstrapManifest = @@BootstrapManifest@@
 
-g.bootstrap.chooseStageCmd = .bootstrap/bin/choosestage
+g.bootstrap.chooseStageCmd = ${g.bootstrap.buildDir}/.bootstrap/bin/choosestage
 
 g.bootstrap.goRoot = @@GoRoot@@
 
@@ -33,10 +35,10 @@ g.bootstrap.linkCmd = ${g.bootstrap.goToolDir}/${g.bootstrap.goChar}l
 
 g.bootstrap.srcDir = @@SrcDir@@
 
-builddir = .minibootstrap
+builddir = ${g.bootstrap.buildDir}/.minibootstrap
 
 rule g.bootstrap.bootstrap
-    command = ${g.bootstrap.bootstrapCmd} -i ${in}
+    command = ${g.bootstrap.bootstrapCmd} -i ${in} -b ${g.bootstrap.buildDir}
     description = bootstrap ${in}
     generator = true
 
@@ -63,21 +65,24 @@ rule g.bootstrap.link
 # Factory: github.com/google/blueprint/bootstrap.func·002
 # Defined: Blueprints:1:1
 
-build .bootstrap/blueprint/pkg/github.com/google/blueprint.a: g.bootstrap.gc $
-        ${g.bootstrap.srcDir}/context.go ${g.bootstrap.srcDir}/live_tracker.go $
-        ${g.bootstrap.srcDir}/mangle.go ${g.bootstrap.srcDir}/module_ctx.go $
+build $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg/github.com/google/blueprint.a $
+        : g.bootstrap.gc ${g.bootstrap.srcDir}/context.go $
+        ${g.bootstrap.srcDir}/live_tracker.go ${g.bootstrap.srcDir}/mangle.go $
+        ${g.bootstrap.srcDir}/module_ctx.go $
         ${g.bootstrap.srcDir}/ninja_defs.go $
         ${g.bootstrap.srcDir}/ninja_strings.go $
         ${g.bootstrap.srcDir}/ninja_writer.go $
         ${g.bootstrap.srcDir}/package_ctx.go ${g.bootstrap.srcDir}/scope.go $
         ${g.bootstrap.srcDir}/singleton_ctx.go ${g.bootstrap.srcDir}/unpack.go $
         | ${g.bootstrap.gcCmd} $
-        .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
-        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
-        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a
-    incFlags = -I .bootstrap/blueprint-parser/pkg -I .bootstrap/blueprint-pathtools/pkg -I .bootstrap/blueprint-proptools/pkg
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a
+    incFlags = -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg
     pkgPath = github.com/google/blueprint
-default .bootstrap/blueprint/pkg/github.com/google/blueprint.a
+default $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg/github.com/google/blueprint.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  blueprint-bootstrap
@@ -87,23 +92,23 @@ default .bootstrap/blueprint/pkg/github.com/google/blueprint.a
 # Defined: Blueprints:70:1
 
 build $
-        .bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a $
         : g.bootstrap.gc ${g.bootstrap.srcDir}/bootstrap/bootstrap.go $
         ${g.bootstrap.srcDir}/bootstrap/cleanup.go $
         ${g.bootstrap.srcDir}/bootstrap/command.go $
         ${g.bootstrap.srcDir}/bootstrap/config.go $
         ${g.bootstrap.srcDir}/bootstrap/doc.go $
         ${g.bootstrap.srcDir}/bootstrap/writedocs.go | ${g.bootstrap.gcCmd} $
-        .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
-        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
-        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
-        .bootstrap/blueprint/pkg/github.com/google/blueprint.a $
-        .bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
-        .bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a
-    incFlags = -I .bootstrap/blueprint-parser/pkg -I .bootstrap/blueprint-pathtools/pkg -I .bootstrap/blueprint-proptools/pkg -I .bootstrap/blueprint/pkg -I .bootstrap/blueprint-deptools/pkg -I .bootstrap/blueprint-bootstrap-bpdoc/pkg
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg/github.com/google/blueprint.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a
+    incFlags = -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg
     pkgPath = github.com/google/blueprint/bootstrap
 default $
-        .bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  blueprint-bootstrap-bpdoc
@@ -113,17 +118,17 @@ default $
 # Defined: Blueprints:89:1
 
 build $
-        .bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a $
         : g.bootstrap.gc ${g.bootstrap.srcDir}/bootstrap/bpdoc/bpdoc.go | $
         ${g.bootstrap.gcCmd} $
-        .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
-        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
-        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
-        .bootstrap/blueprint/pkg/github.com/google/blueprint.a
-    incFlags = -I .bootstrap/blueprint-parser/pkg -I .bootstrap/blueprint-pathtools/pkg -I .bootstrap/blueprint-proptools/pkg -I .bootstrap/blueprint/pkg
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg/github.com/google/blueprint.a
+    incFlags = -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg
     pkgPath = github.com/google/blueprint/bootstrap/bpdoc
 default $
-        .bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  blueprint-deptools
@@ -132,12 +137,13 @@ default $
 # Factory: github.com/google/blueprint/bootstrap.func·002
 # Defined: Blueprints:46:1
 
-build .bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
+build $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
         : g.bootstrap.gc ${g.bootstrap.srcDir}/deptools/depfile.go | $
         ${g.bootstrap.gcCmd}
     pkgPath = github.com/google/blueprint/deptools
 default $
-        .bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  blueprint-parser
@@ -146,13 +152,15 @@ default $
 # Factory: github.com/google/blueprint/bootstrap.func·002
 # Defined: Blueprints:31:1
 
-build .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a: $
-        g.bootstrap.gc ${g.bootstrap.srcDir}/parser/modify.go $
+build $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
+        : g.bootstrap.gc ${g.bootstrap.srcDir}/parser/modify.go $
         ${g.bootstrap.srcDir}/parser/parser.go $
         ${g.bootstrap.srcDir}/parser/printer.go $
         ${g.bootstrap.srcDir}/parser/sort.go | ${g.bootstrap.gcCmd}
     pkgPath = github.com/google/blueprint/parser
-default .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a
+default $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  blueprint-pathtools
@@ -162,12 +170,12 @@ default .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a
 # Defined: Blueprints:52:1
 
 build $
-        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
         : g.bootstrap.gc ${g.bootstrap.srcDir}/pathtools/lists.go $
         ${g.bootstrap.srcDir}/pathtools/glob.go | ${g.bootstrap.gcCmd}
     pkgPath = github.com/google/blueprint/pathtools
 default $
-        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  blueprint-proptools
@@ -177,12 +185,12 @@ default $
 # Defined: Blueprints:64:1
 
 build $
-        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
         : g.bootstrap.gc ${g.bootstrap.srcDir}/proptools/proptools.go | $
         ${g.bootstrap.gcCmd}
     pkgPath = github.com/google/blueprint/proptools
 default $
-        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  choosestage
@@ -191,17 +199,19 @@ default $
 # Factory: github.com/google/blueprint/bootstrap.func·003
 # Defined: Blueprints:127:1
 
-build .bootstrap/choosestage/obj/choosestage.a: g.bootstrap.gc $
-        ${g.bootstrap.srcDir}/choosestage/choosestage.go | $
+build ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/choosestage.a: $
+        g.bootstrap.gc ${g.bootstrap.srcDir}/choosestage/choosestage.go | $
         ${g.bootstrap.gcCmd}
     pkgPath = choosestage
-default .bootstrap/choosestage/obj/choosestage.a
+default ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/choosestage.a
 
-build .bootstrap/choosestage/obj/a.out: g.bootstrap.link $
-        .bootstrap/choosestage/obj/choosestage.a | ${g.bootstrap.linkCmd}
-default .bootstrap/choosestage/obj/a.out
+build ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/a.out: $
+        g.bootstrap.link $
+        ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/choosestage.a | $
+        ${g.bootstrap.linkCmd}
+default ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/a.out
 build ${g.bootstrap.BinDir}/choosestage: g.bootstrap.cp $
-        .bootstrap/choosestage/obj/a.out
+        ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/a.out
 default ${g.bootstrap.BinDir}/choosestage
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -211,16 +221,19 @@ default ${g.bootstrap.BinDir}/choosestage
 # Factory: github.com/google/blueprint/bootstrap.func·003
 # Defined: Blueprints:122:1
 
-build .bootstrap/gotestmain/obj/gotestmain.a: g.bootstrap.gc $
-        ${g.bootstrap.srcDir}/gotestmain/gotestmain.go | ${g.bootstrap.gcCmd}
+build ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/gotestmain.a: $
+        g.bootstrap.gc ${g.bootstrap.srcDir}/gotestmain/gotestmain.go | $
+        ${g.bootstrap.gcCmd}
     pkgPath = gotestmain
-default .bootstrap/gotestmain/obj/gotestmain.a
+default ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/gotestmain.a
 
-build .bootstrap/gotestmain/obj/a.out: g.bootstrap.link $
-        .bootstrap/gotestmain/obj/gotestmain.a | ${g.bootstrap.linkCmd}
-default .bootstrap/gotestmain/obj/a.out
+build ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/a.out: $
+        g.bootstrap.link $
+        ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/gotestmain.a | $
+        ${g.bootstrap.linkCmd}
+default ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/a.out
 build ${g.bootstrap.BinDir}/gotestmain: g.bootstrap.cp $
-        .bootstrap/gotestmain/obj/a.out
+        ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/a.out
 default ${g.bootstrap.BinDir}/gotestmain
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -230,25 +243,27 @@ default ${g.bootstrap.BinDir}/gotestmain
 # Factory: github.com/google/blueprint/bootstrap.func·003
 # Defined: Blueprints:101:1
 
-build .bootstrap/minibp/obj/minibp.a: g.bootstrap.gc $
+build ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/minibp.a: g.bootstrap.gc $
         ${g.bootstrap.srcDir}/bootstrap/minibp/main.go | ${g.bootstrap.gcCmd} $
-        .bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
-        .bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
-        .bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
-        .bootstrap/blueprint/pkg/github.com/google/blueprint.a $
-        .bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
-        .bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a $
-        .bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a
-    incFlags = -I .bootstrap/blueprint-parser/pkg -I .bootstrap/blueprint-pathtools/pkg -I .bootstrap/blueprint-proptools/pkg -I .bootstrap/blueprint/pkg -I .bootstrap/blueprint-deptools/pkg -I .bootstrap/blueprint-bootstrap-bpdoc/pkg -I .bootstrap/blueprint-bootstrap/pkg
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg/github.com/google/blueprint.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a $
+        ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a
+    incFlags = -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg -I ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap/pkg
     pkgPath = minibp
-default .bootstrap/minibp/obj/minibp.a
+default ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/minibp.a
 
-build .bootstrap/minibp/obj/a.out: g.bootstrap.link $
-        .bootstrap/minibp/obj/minibp.a | ${g.bootstrap.linkCmd}
-    libDirFlags = -L .bootstrap/blueprint-parser/pkg -L .bootstrap/blueprint-pathtools/pkg -L .bootstrap/blueprint-proptools/pkg -L .bootstrap/blueprint/pkg -L .bootstrap/blueprint-deptools/pkg -L .bootstrap/blueprint-bootstrap-bpdoc/pkg -L .bootstrap/blueprint-bootstrap/pkg
-default .bootstrap/minibp/obj/a.out
+build ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/a.out: g.bootstrap.link $
+        ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/minibp.a | $
+        ${g.bootstrap.linkCmd}
+    libDirFlags = -L ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg -L ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg -L ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg -L ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg -L ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg -L ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg -L ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap/pkg
+default ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/a.out
 
-build ${g.bootstrap.BinDir}/minibp: g.bootstrap.cp .bootstrap/minibp/obj/a.out
+build ${g.bootstrap.BinDir}/minibp: g.bootstrap.cp $
+        ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/a.out
 default ${g.bootstrap.BinDir}/minibp
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -256,39 +271,44 @@ default ${g.bootstrap.BinDir}/minibp
 # Factory:   github.com/google/blueprint/bootstrap.func·008
 
 rule s.bootstrap.primarybp
-    command = ${g.bootstrap.BinDir}/minibp --build-primary ${runTests} -m ${g.bootstrap.bootstrapManifest} --timestamp ${timestamp} --timestampdep ${timestampdep} -d ${outfile}.d -o ${outfile} ${in}
+    command = ${g.bootstrap.BinDir}/minibp --build-primary ${runTests} -m ${g.bootstrap.bootstrapManifest} --timestamp ${timestamp} --timestampdep ${timestampdep} -b ${g.bootstrap.buildDir} -d ${outfile}.d -o ${outfile} ${in}
     depfile = ${outfile}.d
     description = minibp ${outfile}
 
 rule s.bootstrap.minibp
-    command = ${g.bootstrap.BinDir}/minibp ${runTests} -m ${g.bootstrap.bootstrapManifest} -d ${out}.d -o ${out} ${in}
+    command = ${g.bootstrap.BinDir}/minibp ${runTests} -m ${g.bootstrap.bootstrapManifest} -b ${g.bootstrap.buildDir} -d ${out}.d -o ${out} ${in}
     depfile = ${out}.d
     description = minibp ${out}
     generator = true
 
-build .bootstrap/primary.ninja.in .bootstrap/primary.ninja.in.timestamp: $
+build ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in $
+        ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in.timestamp: $
         s.bootstrap.primarybp ${g.bootstrap.srcDir}/Blueprints | $
         ${g.bootstrap.BinDir}/choosestage ${g.bootstrap.BinDir}/gotestmain $
         ${g.bootstrap.BinDir}/minibp ${g.bootstrap.srcDir}/Blueprints
-    outfile = .bootstrap/primary.ninja.in
-    timestamp = .bootstrap/primary.ninja.in.timestamp
-    timestampdep = .bootstrap/primary.ninja.in.timestamp.d
-default .bootstrap/primary.ninja.in .bootstrap/primary.ninja.in.timestamp
+    outfile = ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in
+    timestamp = ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in.timestamp
+    timestampdep = ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in.timestamp.d
+default ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in $
+        ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in.timestamp
 
-build .bootstrap/bootstrap.ninja.in: s.bootstrap.minibp $
-        ${g.bootstrap.srcDir}/Blueprints | ${g.bootstrap.bootstrapManifest} $
-        ${g.bootstrap.BinDir}/minibp
-default .bootstrap/bootstrap.ninja.in
-build .bootstrap/notAFile: phony
-default .bootstrap/notAFile
-build .bootstrap/build.ninja.in: g.bootstrap.chooseStage $
-        .bootstrap/bootstrap.ninja.in .bootstrap/primary.ninja.in | $
+build ${g.bootstrap.buildDir}/.bootstrap/bootstrap.ninja.in: $
+        s.bootstrap.minibp ${g.bootstrap.srcDir}/Blueprints | $
+        ${g.bootstrap.bootstrapManifest} ${g.bootstrap.BinDir}/minibp
+default ${g.bootstrap.buildDir}/.bootstrap/bootstrap.ninja.in
+build ${g.bootstrap.buildDir}/.bootstrap/notAFile: phony
+default ${g.bootstrap.buildDir}/.bootstrap/notAFile
+build ${g.bootstrap.buildDir}/.bootstrap/build.ninja.in: $
+        g.bootstrap.chooseStage $
+        ${g.bootstrap.buildDir}/.bootstrap/bootstrap.ninja.in $
+        ${g.bootstrap.buildDir}/.bootstrap/primary.ninja.in | $
         ${g.bootstrap.chooseStageCmd} ${g.bootstrap.bootstrapManifest} $
-        .bootstrap/notAFile
-    current = .bootstrap/bootstrap.ninja.in
-default .bootstrap/build.ninja.in
+        ${g.bootstrap.buildDir}/.bootstrap/notAFile
+    current = ${g.bootstrap.buildDir}/.bootstrap/bootstrap.ninja.in
+default ${g.bootstrap.buildDir}/.bootstrap/build.ninja.in
 
-build build.ninja: g.bootstrap.bootstrap .bootstrap/build.ninja.in | $
+build ${g.bootstrap.buildDir}/build.ninja: g.bootstrap.bootstrap $
+        ${g.bootstrap.buildDir}/.bootstrap/build.ninja.in | $
         ${g.bootstrap.bootstrapCmd}
-default build.ninja
+default ${g.bootstrap.buildDir}/build.ninja
 

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -9,6 +9,8 @@
 #
 ninja_required_version = 1.6.0
 
+g.bootstrap.BinDir = .bootstrap/bin
+
 g.bootstrap.bootstrapCmd = @@Bootstrap@@
 
 g.bootstrap.bootstrapManifest = @@BootstrapManifest@@
@@ -198,9 +200,9 @@ default .bootstrap/choosestage/obj/choosestage.a
 build .bootstrap/choosestage/obj/a.out: g.bootstrap.link $
         .bootstrap/choosestage/obj/choosestage.a | ${g.bootstrap.linkCmd}
 default .bootstrap/choosestage/obj/a.out
-build .bootstrap/bin/choosestage: g.bootstrap.cp $
+build ${g.bootstrap.BinDir}/choosestage: g.bootstrap.cp $
         .bootstrap/choosestage/obj/a.out
-default .bootstrap/bin/choosestage
+default ${g.bootstrap.BinDir}/choosestage
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  gotestmain
@@ -217,9 +219,9 @@ default .bootstrap/gotestmain/obj/gotestmain.a
 build .bootstrap/gotestmain/obj/a.out: g.bootstrap.link $
         .bootstrap/gotestmain/obj/gotestmain.a | ${g.bootstrap.linkCmd}
 default .bootstrap/gotestmain/obj/a.out
-build .bootstrap/bin/gotestmain: g.bootstrap.cp $
+build ${g.bootstrap.BinDir}/gotestmain: g.bootstrap.cp $
         .bootstrap/gotestmain/obj/a.out
-default .bootstrap/bin/gotestmain
+default ${g.bootstrap.BinDir}/gotestmain
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Module:  minibp
@@ -246,28 +248,28 @@ build .bootstrap/minibp/obj/a.out: g.bootstrap.link $
     libDirFlags = -L .bootstrap/blueprint-parser/pkg -L .bootstrap/blueprint-pathtools/pkg -L .bootstrap/blueprint-proptools/pkg -L .bootstrap/blueprint/pkg -L .bootstrap/blueprint-deptools/pkg -L .bootstrap/blueprint-bootstrap-bpdoc/pkg -L .bootstrap/blueprint-bootstrap/pkg
 default .bootstrap/minibp/obj/a.out
 
-build .bootstrap/bin/minibp: g.bootstrap.cp .bootstrap/minibp/obj/a.out
-default .bootstrap/bin/minibp
+build ${g.bootstrap.BinDir}/minibp: g.bootstrap.cp .bootstrap/minibp/obj/a.out
+default ${g.bootstrap.BinDir}/minibp
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Singleton: bootstrap
 # Factory:   github.com/google/blueprint/bootstrap.func·008
 
 rule s.bootstrap.primarybp
-    command = .bootstrap/bin/minibp --build-primary ${runTests} -m ${g.bootstrap.bootstrapManifest} --timestamp ${timestamp} --timestampdep ${timestampdep} -d ${outfile}.d -o ${outfile} ${in}
+    command = ${g.bootstrap.BinDir}/minibp --build-primary ${runTests} -m ${g.bootstrap.bootstrapManifest} --timestamp ${timestamp} --timestampdep ${timestampdep} -d ${outfile}.d -o ${outfile} ${in}
     depfile = ${outfile}.d
     description = minibp ${outfile}
 
 rule s.bootstrap.minibp
-    command = .bootstrap/bin/minibp ${runTests} -m ${g.bootstrap.bootstrapManifest} -d ${out}.d -o ${out} ${in}
+    command = ${g.bootstrap.BinDir}/minibp ${runTests} -m ${g.bootstrap.bootstrapManifest} -d ${out}.d -o ${out} ${in}
     depfile = ${out}.d
     description = minibp ${out}
     generator = true
 
 build .bootstrap/primary.ninja.in .bootstrap/primary.ninja.in.timestamp: $
         s.bootstrap.primarybp ${g.bootstrap.srcDir}/Blueprints | $
-        .bootstrap/bin/choosestage .bootstrap/bin/gotestmain $
-        .bootstrap/bin/minibp ${g.bootstrap.srcDir}/Blueprints
+        ${g.bootstrap.BinDir}/choosestage ${g.bootstrap.BinDir}/gotestmain $
+        ${g.bootstrap.BinDir}/minibp ${g.bootstrap.srcDir}/Blueprints
     outfile = .bootstrap/primary.ninja.in
     timestamp = .bootstrap/primary.ninja.in.timestamp
     timestampdep = .bootstrap/primary.ninja.in.timestamp.d
@@ -275,7 +277,7 @@ default .bootstrap/primary.ninja.in .bootstrap/primary.ninja.in.timestamp
 
 build .bootstrap/bootstrap.ninja.in: s.bootstrap.minibp $
         ${g.bootstrap.srcDir}/Blueprints | ${g.bootstrap.bootstrapManifest} $
-        .bootstrap/bin/minibp
+        ${g.bootstrap.BinDir}/minibp
 default .bootstrap/bootstrap.ninja.in
 build .bootstrap/notAFile: phony
 default .bootstrap/notAFile

--- a/choosestage/choosestage.go
+++ b/choosestage/choosestage.go
@@ -135,7 +135,7 @@ func main() {
 			// If we're currently running this stage, and the build.ninja.in
 			// file differs from the current stage file, then it has been rebuilt.
 			// Restart the stage.
-			if currentFile == fileName {
+			if filepath.Clean(currentFile) == filepath.Clean(fileName) {
 				if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
 					if ok, err := compareFiles(fileName, outputFile); err != nil {
 						fmt.Fprintf(os.Stderr, "Failure when comparing files: %s\n", err)


### PR DESCRIPTION
WARNING: API change in the first commit (bootstrap.BinDir)

To provide a consistent __FILE__ behavior with cpp, we want to be able to run with SRCDIR="." and the outputs be saved elsewhere. Other tools within android also expect to be run from $TOP.

This set of changes just removes the assumption that the build directory is always the current working directory. The defaults remain the same, unless -b or $BUILDDIR is passed into bootstrap.bash.