### PR TITLE
Updates to travis config -- faster; ninja v1.6.0

### DIFF
--- a/.travis.fix-fork.sh
+++ b/.travis.fix-fork.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if echo $TRAVIS_BUILD_DIR | grep -vq "github.com/google/blueprint$" ; then
+  cd ../..
+  mkdir -p google
+  mv $TRAVIS_BUILD_DIR google/blueprint
+  cd google/blueprint
+  export TRAVIS_BUILD_DIR=$PWD
+fi

--- a/.travis.install-ninja.sh
+++ b/.travis.install-ninja.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Version of ninja to build -- can be any git revision
+VERSION="v1.6.0"
+
+set -ev
+
+SCRIPT_HASH=$(sha1sum ${BASH_SOURCE[0]} | awk '{print $1}')
+
+cd ~
+if [[ -d ninjabin && "$SCRIPT_HASH" == "$(cat ninjabin/script_hash)" ]]; then
+  exit 0
+fi
+
+git clone https://github.com/martine/ninja
+cd ninja
+./configure.py --bootstrap
+
+mkdir -p ../ninjabin
+rm -f ../ninjabin/ninja
+echo -n $SCRIPT_HASH >../ninjabin/script_hash
+mv ninja ../ninjabin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: go
 
-addons:
-    apt:
-        packages:
-            - ninja-build
+cache:
+    directories:
+        - $HOME/ninjabin
+
+install:
+    - ./.travis.install-ninja.sh
+    - export PATH=$PATH:~/ninjabin
 
 before_script:
     - source .travis.fix-fork.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 install:
     - sudo apt-get install ninja-build
 
+before_script:
+    - source .travis.fix-fork.sh
+
 script:
     - go test ./...
     - cp build.ninja.in build.ninja.in.orig

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 
-install:
-    - sudo apt-get install ninja-build
+addons:
+    apt:
+        packages:
+            - ninja-build
 
 before_script:
     - source .travis.fix-fork.sh


### PR DESCRIPTION
* Fix running travis on forks by moving the code around to always be gopath/src/github.com/google/blueprint
* Migrate to the container based travis setup. This should make our builds start faster according to the docs, since they can scale containers faster than VMs.
* Use ninja v1.6.0, built from source (and cached between builds).