### PR TITLE
Fix bootstrap and separate buildDir ninja cleanup

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -23,8 +23,8 @@ import (
 	"github.com/google/blueprint/pathtools"
 )
 
-const bootstrapDir = "$buildDir/.bootstrap"
-const miniBootstrapDir = "$buildDir/.minibootstrap"
+const bootstrapSubDir = ".bootstrap"
+const miniBootstrapSubDir = ".minibootstrap"
 
 var (
 	pctx = blueprint.NewPackageContext("github.com/google/blueprint/bootstrap")
@@ -102,6 +102,9 @@ var (
 	minibpFile = filepath.Join("$BinDir", "minibp")
 
 	docsDir = filepath.Join(bootstrapDir, "docs")
+
+	bootstrapDir = filepath.Join("$buildDir", bootstrapSubDir)
+	miniBootstrapDir = filepath.Join("$buildDir", miniBootstrapSubDir)
 )
 
 type bootstrapGoCore interface {

--- a/bootstrap/cleanup.go
+++ b/bootstrap/cleanup.go
@@ -32,12 +32,12 @@ const logFileName = ".ninja_log"
 func removeAbandonedFiles(ctx *blueprint.Context, config *Config,
 	srcDir, manifestFile string) error {
 
-	buildDir := "."
+	buildDir := BuildDir
 	switch config.stage {
 	case StageBootstrap:
-		buildDir = miniBootstrapDir
+		buildDir = filepath.Join(buildDir, miniBootstrapSubDir)
 	case StagePrimary:
-		buildDir = bootstrapDir
+		buildDir = filepath.Join(buildDir, bootstrapSubDir)
 	}
 
 	targetRules, err := ctx.AllTargets()


### PR DESCRIPTION
With the introduction of $buildDir in bootstrapDir, the ninja cleanup
step hasn't been able to cleanup during the bootstrap stages. The main
stage was unaffected, as long as you were using "." as your buildDir.
