### PR TITLE
"Stop using bootstrap.bash -b for separate builddir

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -78,7 +78,7 @@ var (
 
 	bootstrap = pctx.StaticRule("bootstrap",
 		blueprint.RuleParams{
-			Command:     "$bootstrapCmd -i $in -b $buildDir",
+			Command:     "BUILDDIR=$buildDir $bootstrapCmd -i $in",
 			Description: "bootstrap $in",
 			Generator:   true,
 		})

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -30,7 +30,7 @@ g.bootstrap.srcDir = @@SrcDir@@
 builddir = ${g.bootstrap.buildDir}/.minibootstrap
 
 rule g.bootstrap.bootstrap
-    command = ${g.bootstrap.bootstrapCmd} -i ${in} -b ${g.bootstrap.buildDir}
+    command = BUILDDIR=${g.bootstrap.buildDir} ${g.bootstrap.bootstrapCmd} -i ${in}
     description = bootstrap ${in}
     generator = true
 


### PR DESCRIPTION
It's difficult for wrapping scripts to handle -b properly. Just pass
BUILDDIR instead, which is easier to handle. This still accepts -b, so
that incremental builds work across this change.