### PR TITLE
Add walkDeps to context and module_ctx.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1825,6 +1825,29 @@ func (c *Context) processLocalBuildActions(out, in *localBuildActions,
 	return nil
 }
 
+func (c *Context) walkDeps(topModule *moduleInfo,
+	shouldWalk func(Module, Module) bool, visit func(Module)) {
+
+	visited := make(map[*moduleInfo]bool)
+
+	var walk func(module *moduleInfo)
+	walk = func(module *moduleInfo) {
+		visited[module] = true
+
+		for _, moduleDep := range module.directDeps {
+			if !visited[moduleDep] && shouldWalk(module.logicModule, moduleDep.logicModule) {
+				walk(moduleDep)
+			}
+		}
+
+		if module != topModule {
+			visit(module.logicModule)
+		}
+	}
+
+	walk(topModule)
+}
+
 func (c *Context) visitDepsDepthFirst(topModule *moduleInfo, visit func(Module)) {
 	visited := make(map[*moduleInfo]bool)
 

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -133,6 +133,7 @@ type ModuleContext interface {
 	VisitDirectDepsIf(pred func(Module) bool, visit func(Module))
 	VisitDepsDepthFirst(visit func(Module))
 	VisitDepsDepthFirstIf(pred func(Module) bool, visit func(Module))
+	WalkDeps(shouldWalk func(Module, Module) bool, visit func(Module))
 
 	ModuleSubDir() string
 
@@ -249,6 +250,10 @@ func (m *moduleContext) VisitDepsDepthFirstIf(pred func(Module) bool,
 	visit func(Module)) {
 
 	m.context.visitDepsDepthFirstIf(m.module, pred, visit)
+}
+
+func (m *moduleContext) WalkDeps(shouldWalk func(Module, Module) bool, visit func(Module)) {
+	m.context.walkDeps(m.module, shouldWalk, visit)
 }
 
 func (m *moduleContext) ModuleSubDir() string {


### PR DESCRIPTION
walkDeps is similar to visitDepsDepthFirst, except that the
shouldWalk predicate determines if a dependency edge should be
traversed.