### PR TITLE
Add walkDeps to context and module_ctx.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1825,6 +1825,27 @@ func (c *Context) processLocalBuildActions(out, in *localBuildActions,
 	return nil
 }
 
+func (c *Context) walkDeps(topModule *moduleInfo,
+	visit func(Module, Module) bool) {
+
+	visited := make(map[*moduleInfo]bool)
+
+	var walk func(module *moduleInfo)
+	walk = func(module *moduleInfo) {
+		visited[module] = true
+
+		for _, moduleDep := range module.directDeps {
+			if !visited[moduleDep] {
+				if visit(moduleDep.logicModule, module.logicModule) {
+					walk(moduleDep)
+				}
+			}
+		}
+	}
+
+	walk(topModule)
+}
+
 func (c *Context) visitDepsDepthFirst(topModule *moduleInfo, visit func(Module)) {
 	visited := make(map[*moduleInfo]bool)
 

--- a/context_test_Blueprints
+++ b/context_test_Blueprints
@@ -1,0 +1,32 @@
+foo_module {
+    name: "A",
+    deps: ["B", "C"],
+}
+
+bar_module {
+    name: "B",
+    deps: ["D"],
+}
+
+foo_module {
+    name: "C",
+    deps: ["E", "F"],
+}
+
+foo_module {
+    name: "D",
+}
+
+bar_module {
+    name: "E",
+    deps: ["G"],
+}
+
+foo_module {
+    name: "F",
+    deps: ["G"],
+}
+
+foo_module {
+    name: "G",
+}

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -133,6 +133,7 @@ type ModuleContext interface {
 	VisitDirectDepsIf(pred func(Module) bool, visit func(Module))
 	VisitDepsDepthFirst(visit func(Module))
 	VisitDepsDepthFirstIf(pred func(Module) bool, visit func(Module))
+	WalkDeps(visit func(Module, Module) bool)
 
 	ModuleSubDir() string
 
@@ -249,6 +250,10 @@ func (m *moduleContext) VisitDepsDepthFirstIf(pred func(Module) bool,
 	visit func(Module)) {
 
 	m.context.visitDepsDepthFirstIf(m.module, pred, visit)
+}
+
+func (m *moduleContext) WalkDeps(visit func(Module, Module) bool) {
+	m.context.walkDeps(m.module, visit)
 }
 
 func (m *moduleContext) ModuleSubDir() string {
@@ -382,6 +387,7 @@ type TopDownMutatorContext interface {
 	VisitDirectDepsIf(pred func(Module) bool, visit func(Module))
 	VisitDepsDepthFirst(visit func(Module))
 	VisitDepsDepthFirstIf(pred func(Module) bool, visit func(Module))
+	WalkDeps(visit func(Module, Module) bool)
 }
 
 type BottomUpMutatorContext interface {
@@ -500,4 +506,8 @@ func (mctx *mutatorContext) VisitDepsDepthFirstIf(pred func(Module) bool,
 	visit func(Module)) {
 
 	mctx.context.visitDepsDepthFirstIf(mctx.module, pred, visit)
+}
+
+func (mctx *mutatorContext) WalkDeps(visit func(Module, Module) bool) {
+	mctx.context.walkDeps(mctx.module, visit)
 }


### PR DESCRIPTION
walkDeps performs a pre-order DFS (unlike visitDepsDepthFirst which is
a post-order DFS). The visit function takes in both a parent and child
node and returns a bool indicating if the child node should be
traversed.