### PR TITLE
Print useful error for self-dependency

### DIFF
--- a/context.go
+++ b/context.go
@@ -1214,6 +1214,12 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 			found = m.variant.equal(newVariant)
 		}
 		if found {
+			if module == m {
+				return []error{&Error{
+					Err: fmt.Errorf("%q depends on itself", depName),
+					Pos: depsPos,
+				}}
+			}
 			// AddVariationDependency allows adding a dependency on itself, but only if
 			// that module is earlier in the module list than this one, since we always
 			// run GenerateBuildActions in order for the variants of a module
@@ -2615,6 +2621,9 @@ func (c *Context) writeLocalBuildActions(nw *ninjaWriter,
 
 func beforeInModuleList(a, b *moduleInfo, list []*moduleInfo) bool {
 	found := false
+	if a == b {
+		return false
+	}
 	for _, l := range list {
 		if l == a {
 			found = true


### PR DESCRIPTION
beforeInModuleList panic'd when checking if a variant was before itself
in the module list.  Return a real error instead of calling
beforeInModuleList, and also fix beforeInModuleList to return false for
the same module.