### PR TITLE
Don't rely on deps property position

### DIFF
--- a/context.go
+++ b/context.go
@@ -1112,12 +1112,10 @@ func (c *Context) findMatchingVariant(module *moduleInfo, group *moduleGroup) *m
 }
 
 func (c *Context) addDependency(module *moduleInfo, depName string) []error {
-	depsPos := module.propertyPos["deps"]
-
 	if depName == module.properties.Name {
 		return []error{&Error{
 			Err: fmt.Errorf("%q depends on itself", depName),
-			Pos: depsPos,
+			Pos: module.pos,
 		}}
 	}
 
@@ -1126,7 +1124,7 @@ func (c *Context) addDependency(module *moduleInfo, depName string) []error {
 		return []error{&Error{
 			Err: fmt.Errorf("%q depends on undefined module %q",
 				module.properties.Name, depName),
-			Pos: depsPos,
+			Pos: module.pos,
 		}}
 	}
 
@@ -1145,7 +1143,7 @@ func (c *Context) addDependency(module *moduleInfo, depName string) []error {
 		Err: fmt.Errorf("dependency %q of %q missing variant %q",
 			depInfo.modules[0].properties.Name, module.properties.Name,
 			c.prettyPrintVariant(module.dependencyVariant)),
-		Pos: depsPos,
+		Pos: module.pos,
 	}}
 }
 
@@ -1182,14 +1180,12 @@ func (c *Context) addReverseDependency(module *moduleInfo, destName string) []er
 func (c *Context) addVariationDependency(module *moduleInfo, variations []Variation,
 	depName string, far bool) []error {
 
-	depsPos := module.propertyPos["deps"]
-
 	depInfo, ok := c.moduleGroups[depName]
 	if !ok {
 		return []error{&Error{
 			Err: fmt.Errorf("%q depends on undefined module %q",
 				module.properties.Name, depName),
-			Pos: depsPos,
+			Pos: module.pos,
 		}}
 	}
 
@@ -1217,7 +1213,7 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 			if module == m {
 				return []error{&Error{
 					Err: fmt.Errorf("%q depends on itself", depName),
-					Pos: depsPos,
+					Pos: module.pos,
 				}}
 			}
 			// AddVariationDependency allows adding a dependency on itself, but only if
@@ -1226,7 +1222,7 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 			if depInfo == module.group && beforeInModuleList(module, m, module.group.modules) {
 				return []error{&Error{
 					Err: fmt.Errorf("%q depends on later version of itself", depName),
-					Pos: depsPos,
+					Pos: module.pos,
 				}}
 			}
 			module.directDeps = append(module.directDeps, m)
@@ -1238,7 +1234,7 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 		Err: fmt.Errorf("dependency %q of %q missing variant %q",
 			depInfo.modules[0].properties.Name, module.properties.Name,
 			c.prettyPrintVariant(newVariant)),
-		Pos: depsPos,
+		Pos: module.pos,
 	}}
 }
 
@@ -1316,7 +1312,7 @@ func (c *Context) updateDependencies() (errs []error) {
 				Err: fmt.Errorf("    %q depends on %q",
 					curModule.properties.Name,
 					nextModule.properties.Name),
-				Pos: curModule.propertyPos["deps"],
+				Pos: curModule.pos,
 			})
 			curModule = nextModule
 		}


### PR DESCRIPTION
Dependency errors were prefixed with ??? because they were associated
with the position of the "deps" property, which is often not used.  Use
the position of the module instead.