### PR TITLE
Update expected output for manifest test.

### DIFF
--- a/tests/expected_manifest
+++ b/tests/expected_manifest
@@ -1,4 +1,6 @@
 Newer source version of build.ninja.in. Copying to bootstrap.ninja.in
 Choosing bootstrap.ninja.in for next stage
+Stage bootstrap.ninja.in has changed, restarting
+Choosing bootstrap.ninja.in for next stage
 Choosing primary.ninja.in for next stage
 Choosing main.ninja.in for next stage


### PR DESCRIPTION
Note: I think this patch is correct, but TBH I'm not sure.
[maybe this is papering over a different bug?]

@ruffy:blueprint$ sh tests/test.sh
Running start... Passed.
Running all... Passed.
Running primary... Passed.
Running none... Passed.
Running manifest... Failed.
Regenerating src.build.ninja.in
Running start2... Passed.
Running regen... Passed.
Regenerating src.build.ninja.in
Running start_add_tests... Passed.
Running rebuild_test... Passed.
Test manifest Failed:
--- ../tests/expected_manifest	2015-11-08 10:39:27.852511804 -0800
+++ test_manifest	2015-11-08 12:47:51.494881305 -0800
@@ -1,4 +1,6 @@
 Newer source version of build.ninja.in. Copying to bootstrap.ninja.in
 Choosing bootstrap.ninja.in for next stage
+Stage bootstrap.ninja.in has changed, restarting
+Choosing bootstrap.ninja.in for next stage
 Choosing primary.ninja.in for next stage
 Choosing main.ninja.in for next stage