### PR TITLE
Update travis to use go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+    - 1.5.1
+
 cache:
     directories:
         - $HOME/ninjabin

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -54,7 +54,7 @@ rule g.bootstrap.link
 # Module:  blueprint
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:1:1
 
 build $
@@ -80,7 +80,7 @@ default $
 # Module:  blueprint-bootstrap
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:80:1
 
 build $
@@ -107,7 +107,7 @@ default $
 # Module:  blueprint-bootstrap-bpdoc
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:99:1
 
 build $
@@ -127,7 +127,7 @@ default $
 # Module:  blueprint-deptools
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:46:1
 
 build $
@@ -142,7 +142,7 @@ default $
 # Module:  blueprint-parser
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:31:1
 
 build $
@@ -159,7 +159,7 @@ default $
 # Module:  blueprint-pathtools
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:52:1
 
 build $
@@ -174,7 +174,7 @@ default $
 # Module:  blueprint-proptools
 # Variant:
 # Type:    bootstrap_go_package
-# Factory: github.com/google/blueprint/bootstrap.func·003
+# Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
 # Defined: Blueprints:64:1
 
 build $
@@ -192,7 +192,7 @@ default $
 # Module:  choosestage
 # Variant:
 # Type:    bootstrap_core_go_binary
-# Factory: github.com/google/blueprint/bootstrap.func·005
+# Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
 # Defined: Blueprints:142:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/choosestage.a: $
@@ -214,7 +214,7 @@ default ${g.bootstrap.BinDir}/choosestage
 # Module:  gotestmain
 # Variant:
 # Type:    bootstrap_core_go_binary
-# Factory: github.com/google/blueprint/bootstrap.func·005
+# Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
 # Defined: Blueprints:132:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/gotestmain.a: $
@@ -236,7 +236,7 @@ default ${g.bootstrap.BinDir}/gotestmain
 # Module:  gotestrunner
 # Variant:
 # Type:    bootstrap_core_go_binary
-# Factory: github.com/google/blueprint/bootstrap.func·005
+# Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
 # Defined: Blueprints:137:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/gotestrunner/obj/gotestrunner.a: $
@@ -258,7 +258,7 @@ default ${g.bootstrap.BinDir}/gotestrunner
 # Module:  minibp
 # Variant:
 # Type:    bootstrap_core_go_binary
-# Factory: github.com/google/blueprint/bootstrap.func·005
+# Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
 # Defined: Blueprints:111:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/minibp.a: $
@@ -287,7 +287,7 @@ default ${g.bootstrap.BinDir}/minibp
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Singleton: bootstrap
-# Factory:   github.com/google/blueprint/bootstrap.func·012
+# Factory:   github.com/google/blueprint/bootstrap.newSingletonFactory.func1
 
 rule s.bootstrap.primarybp
     command = ${g.bootstrap.BinDir}/minibp --build-primary ${runTests} -m ${g.bootstrap.bootstrapManifest} --timestamp ${timestamp} --timestampdep ${timestampdep} -b ${g.bootstrap.buildDir} -d ${outfile}.d -o ${outfile} ${in}


### PR DESCRIPTION
Update .travis.yml to specify go 1.5.1, and update build.ninja.in to
include the new in line function names used by go 1.5.