### PR TITLE
Add variant methods to SingletonContext and Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -2144,6 +2144,23 @@ func (c *Context) VisitDepsDepthFirstIf(module Module,
 	c.visitDepsDepthFirstIf(c.moduleInfo[module], pred, visit)
 }
 
+func (c *Context) PrimaryModule(module Module) Module {
+	return c.moduleInfo[module].group.modules[0].logicModule
+}
+
+func (c *Context) FinalModule(module Module) Module {
+	modules := c.moduleInfo[module].group.modules
+	return modules[len(modules)-1].logicModule
+}
+
+func (c *Context) VisitAllModuleVariants(module Module,
+	visit func(Module)) {
+
+	for _, module := range c.moduleInfo[module].group.modules {
+		visit(module.logicModule)
+	}
+}
+
 // WriteBuildFile writes the Ninja manifeset text for the generated build
 // actions to w.  If this is called before PrepareBuildActions successfully
 // completes then ErrBuildActionsNotReady is returned.

--- a/singleton_ctx.go
+++ b/singleton_ctx.go
@@ -49,6 +49,11 @@ type SingletonContext interface {
 	VisitDepsDepthFirstIf(module Module, pred func(Module) bool,
 		visit func(Module))
 
+	VisitAllModuleVariants(module Module, visit func(Module))
+
+	PrimaryModule(module Module) Module
+	FinalModule(module Module) Module
+
 	AddNinjaFileDeps(deps ...string)
 }
 
@@ -164,6 +169,18 @@ func (s *singletonContext) VisitDepsDepthFirstIf(module Module,
 	pred func(Module) bool, visit func(Module)) {
 
 	s.context.VisitDepsDepthFirstIf(module, pred, visit)
+}
+
+func (s *singletonContext) PrimaryModule(module Module) Module {
+	return s.context.PrimaryModule(module)
+}
+
+func (s *singletonContext) FinalModule(module Module) Module {
+	return s.context.FinalModule(module)
+}
+
+func (s *singletonContext) VisitAllModuleVariants(module Module, visit func(Module)) {
+	s.context.VisitAllModuleVariants(module, visit)
 }
 
 func (s *singletonContext) AddNinjaFileDeps(deps ...string) {


### PR DESCRIPTION
Add VisitAllModuleVariants, PrimaryModule, and FinalModule to
SingletonContext so singletons and tools can deal with modules with
multiple variants.