### PR TITLE
End removing directories on ENOTDIR

### DIFF
--- a/bootstrap/cleanup.go
+++ b/bootstrap/cleanup.go
@@ -130,7 +130,7 @@ func removeFileAndEmptyDirs(path string) error {
 		}
 		pathErr := err.(*os.PathError)
 		switch pathErr.Err {
-		case syscall.ENOTEMPTY, syscall.EEXIST:
+		case syscall.ENOTEMPTY, syscall.EEXIST, syscall.ENOTDIR:
 			return nil
 		}
 		return err


### PR DESCRIPTION
An abandoned directory may have been replaced with a file, give up on
removing the directory on ENOTDIR.