### PR TITLE
Make removing abandoned files optional

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -161,10 +161,12 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		}
 	}
 
-	srcDir := filepath.Dir(bootstrapConfig.topLevelBlueprintsFile)
-	err = removeAbandonedFiles(ctx, bootstrapConfig, srcDir, manifestFile)
-	if err != nil {
-		fatalf("error removing abandoned files: %s", err)
+	if c, ok := config.(ConfigRemoveAbandonedFiles); !ok || c.RemoveAbandonedFiles() {
+		srcDir := filepath.Dir(bootstrapConfig.topLevelBlueprintsFile)
+		err := removeAbandonedFiles(ctx, bootstrapConfig, srcDir, manifestFile)
+		if err != nil {
+			fatalf("error removing abandoned files: %s", err)
+		}
 	}
 }
 

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -38,6 +38,12 @@ type ConfigInterface interface {
 	GeneratingPrimaryBuilder() bool
 }
 
+type ConfigRemoveAbandonedFiles interface {
+	// RemoveAbandonedFiles should return true if files listed in the
+	// .ninja_log but not the output build.ninja file should be deleted.
+	RemoveAbandonedFiles() bool
+}
+
 type Stage int
 
 const (


### PR DESCRIPTION
Build logic can now implement a RemoveAbandonedFiles, and the bootstrap
logic will only remove abandoned files if that method returns true.
Leaving the method unimplemented will result in the existing behavior of
always removing abandoned files.