### PR TITLE
Allow multiple calls to ctx.SetBuildDir

### DIFF
--- a/context.go
+++ b/context.go
@@ -1913,10 +1913,9 @@ func (c *Context) requireNinjaVersion(major, minor, micro int) {
 }
 
 func (c *Context) setBuildDir(value *ninjaString) {
-	if c.buildDir != nil {
-		panic("buildDir set multiple times")
+	if c.buildDir == nil {
+		c.buildDir = value
 	}
-	c.buildDir = value
 }
 
 func (c *Context) makeUniquePackageNames(


### PR DESCRIPTION
ctx.SetBuildDir is called by the bootstrap singleton, which is always
last.  In order to allow the primary builder to set the directory for
.ninja_log/.ninja_deps, remove the panic on multiple calls to
ctx.SetBuildDir, and always used the value passed by the first caller.