### PR TITLE
Support embedded anonymous property structs

### DIFF
--- a/bootstrap/bpdoc/bpdoc.go
+++ b/bootstrap/bpdoc/bpdoc.go
@@ -240,8 +240,15 @@ func newDocs(t *doc.Type) (*PropertyStructDocs, error) {
 
 func structProperties(structType *ast.StructType) (props []PropertyDocs, err error) {
 	for _, f := range structType.Fields.List {
-		//fmt.Printf("%T %#v\n", f, f)
-		for _, n := range f.Names {
+		names := f.Names
+		if names == nil {
+			// Anonymous fields have no name, use the type as the name
+			// TODO: hide the name and make the properties show up in the embedding struct
+			if t, ok := f.Type.(*ast.Ident); ok {
+				names = append(names, t)
+			}
+		}
+		for _, n := range names {
 			var name, typ, tag, text string
 			var innerProps []PropertyDocs
 			if n != nil {

--- a/proptools/clone.go
+++ b/proptools/clone.go
@@ -140,7 +140,7 @@ func ZeroProperties(structValue reflect.Value) {
 		fieldValue := structValue.Field(i)
 
 		switch fieldValue.Kind() {
-		case reflect.Bool, reflect.String, reflect.Struct, reflect.Slice, reflect.Int, reflect.Uint:
+		case reflect.Bool, reflect.String, reflect.Slice, reflect.Int, reflect.Uint:
 			fieldValue.Set(reflect.Zero(fieldValue.Type()))
 		case reflect.Interface:
 			if fieldValue.IsNil() {
@@ -172,7 +172,8 @@ func ZeroProperties(structValue reflect.Value) {
 				panic(fmt.Errorf("can't zero field %q: points to a %s",
 					field.Name, fieldValue.Elem().Kind()))
 			}
-
+		case reflect.Struct:
+			ZeroProperties(fieldValue)
 		default:
 			panic(fmt.Errorf("unexpected kind for property struct field %q: %s",
 				field.Name, fieldValue.Kind()))

--- a/proptools/clone_test.go
+++ b/proptools/clone_test.go
@@ -130,6 +130,26 @@ var clonePropertiesTestCases = []struct {
 		},
 	},
 	{
+		// Clone nested interface
+		in: &struct {
+			Nested struct{ S interface{} }
+		}{
+			Nested: struct{ S interface{} }{
+				S: &struct{ S string }{
+					S: "string1",
+				},
+			},
+		},
+		out: &struct {
+			Nested struct{ S interface{} }
+		}{
+			Nested: struct{ S interface{} }{
+				S: &struct{ S string }{
+					S: "string1",
+				},
+			},
+		},
+	}, {
 		// Empty struct
 		in:  &struct{}{},
 		out: &struct{}{},
@@ -268,6 +288,25 @@ var cloneEmptyPropertiesTestCases = []struct {
 		},
 	},
 	{
+		// Clone nested interface
+		in: &struct {
+			Nested struct{ S interface{} }
+		}{
+			Nested: struct{ S interface{} }{
+				S: &struct{ S string }{
+					S: "string1",
+				},
+			},
+		},
+		out: &struct {
+			Nested struct{ S interface{} }
+		}{
+			Nested: struct{ S interface{} }{
+				S: &struct{ S string }{},
+			},
+		},
+	},
+	{
 		// Empty struct
 		in:  &struct{}{},
 		out: &struct{}{},
@@ -295,11 +334,61 @@ var cloneEmptyPropertiesTestCases = []struct {
 		},
 		out: &struct{ S *struct{} }{},
 	},
+	{
+		// Anonymous struct
+		in: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{
+					S: "string2",
+				},
+			},
+		},
+		out: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{},
+			},
+		},
+	},
+	{
+		// Anonymous interface
+		in: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{
+					S: "string2",
+				},
+			},
+		},
+		out: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{},
+			},
+		},
+	},
 }
 
 func TestCloneEmptyProperties(t *testing.T) {
 	for _, testCase := range cloneEmptyPropertiesTestCases {
-		testString := fmt.Sprintf("%s", testCase.in)
+		testString := fmt.Sprintf("%#v", testCase.in)
 
 		got := CloneEmptyProperties(reflect.ValueOf(testCase.in).Elem()).Interface()
 
@@ -314,9 +403,9 @@ func TestCloneEmptyProperties(t *testing.T) {
 
 func TestZeroProperties(t *testing.T) {
 	for _, testCase := range cloneEmptyPropertiesTestCases {
-		testString := fmt.Sprintf("%s", testCase.in)
+		testString := fmt.Sprintf("%#v", testCase.in)
 
-		got := CloneEmptyProperties(reflect.ValueOf(testCase.in).Elem()).Interface()
+		got := CloneProperties(reflect.ValueOf(testCase.in).Elem()).Interface()
 		ZeroProperties(reflect.ValueOf(got).Elem())
 
 		if !reflect.DeepEqual(testCase.out, got) {

--- a/proptools/clone_test.go
+++ b/proptools/clone_test.go
@@ -181,7 +181,68 @@ var clonePropertiesTestCases = []struct {
 			S: nil,
 		},
 	},
+	{
+		// Anonymous struct
+		in: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{
+					S: "string2",
+				},
+			},
+		},
+		out: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{
+					S: "string2",
+				},
+			},
+		},
+	},
+	{
+		// Anonymous interface
+		in: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{
+					S: "string2",
+				},
+			},
+		},
+		out: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{
+					S: "string2",
+				},
+			},
+		},
+	},
 }
+
+type EmbeddedStruct struct{ S string }
+type EmbeddedInterface interface{}
 
 func TestCloneProperties(t *testing.T) {
 	for _, testCase := range clonePropertiesTestCases {

--- a/proptools/extend_test.go
+++ b/proptools/extend_test.go
@@ -409,6 +409,90 @@ var appendPropertiesTestCases = []struct {
 			S: nil,
 		},
 	},
+	{
+		// Anonymous struct
+		in1: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{
+					S: "string2",
+				},
+			},
+		},
+		in2: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				S: "string3",
+			},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{
+					S: "string4",
+				},
+			},
+		},
+		out: &struct {
+			EmbeddedStruct
+			Nested struct{ EmbeddedStruct }
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				S: "string1string3",
+			},
+			Nested: struct{ EmbeddedStruct }{
+				EmbeddedStruct: EmbeddedStruct{
+					S: "string2string4",
+				},
+			},
+		},
+	},
+	{
+		// Anonymous interface
+		in1: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{
+				S: "string1",
+			},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{
+					S: "string2",
+				},
+			},
+		},
+		in2: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{
+				S: "string3",
+			},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{
+					S: "string4",
+				},
+			},
+		},
+		out: &struct {
+			EmbeddedInterface
+			Nested struct{ EmbeddedInterface }
+		}{
+			EmbeddedInterface: &struct{ S string }{
+				S: "string1string3",
+			},
+			Nested: struct{ EmbeddedInterface }{
+				EmbeddedInterface: &struct{ S string }{
+					S: "string2string4",
+				},
+			},
+		},
+	},
 
 	// Errors
 

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -228,7 +228,136 @@ var validUnpackTestCases = []struct {
 			},
 		},
 	},
+
+	// Anonymous struct
+	{`
+		m {
+			name: "abc",
+			nested: {
+				name: "def",
+			},
+		}
+		`,
+		struct {
+			EmbeddedStruct
+			Nested struct {
+				EmbeddedStruct
+			}
+		}{
+			EmbeddedStruct: EmbeddedStruct{
+				Name: "abc",
+			},
+			Nested: struct {
+				EmbeddedStruct
+			}{
+				EmbeddedStruct: EmbeddedStruct{
+					Name: "def",
+				},
+			},
+		},
+		nil,
+	},
+
+	// Anonymous interface
+	{`
+		m {
+			name: "abc",
+			nested: {
+				name: "def",
+			},
+		}
+		`,
+		struct {
+			EmbeddedInterface
+			Nested struct {
+				EmbeddedInterface
+			}
+		}{
+			EmbeddedInterface: &struct{ Name string }{
+				Name: "abc",
+			},
+			Nested: struct {
+				EmbeddedInterface
+			}{
+				EmbeddedInterface: &struct{ Name string }{
+					Name: "def",
+				},
+			},
+		},
+		nil,
+	},
+
+	// Anonymous struct with name collision
+	{`
+		m {
+			name: "abc",
+			nested: {
+				name: "def",
+			},
+		}
+		`,
+		struct {
+			Name string
+			EmbeddedStruct
+			Nested struct {
+				Name string
+				EmbeddedStruct
+			}
+		}{
+			Name: "abc",
+			EmbeddedStruct: EmbeddedStruct{
+				Name: "abc",
+			},
+			Nested: struct {
+				Name string
+				EmbeddedStruct
+			}{
+				Name: "def",
+				EmbeddedStruct: EmbeddedStruct{
+					Name: "def",
+				},
+			},
+		},
+		nil,
+	},
+
+	// Anonymous interface with name collision
+	{`
+		m {
+			name: "abc",
+			nested: {
+				name: "def",
+			},
+		}
+		`,
+		struct {
+			Name string
+			EmbeddedInterface
+			Nested struct {
+				Name string
+				EmbeddedInterface
+			}
+		}{
+			Name: "abc",
+			EmbeddedInterface: &struct{ Name string }{
+				Name: "abc",
+			},
+			Nested: struct {
+				Name string
+				EmbeddedInterface
+			}{
+				Name: "def",
+				EmbeddedInterface: &struct{ Name string }{
+					Name: "def",
+				},
+			},
+		},
+		nil,
+	},
 }
+
+type EmbeddedStruct struct{ Name string }
+type EmbeddedInterface interface{}
 
 func TestUnpackProperties(t *testing.T) {
 	for _, testCase := range validUnpackTestCases {


### PR DESCRIPTION
Allow property structs to contain anonymous embedded structs and
interfaces.  Properties in an anonymous embedded struct or interface are
treated as if they were properties in the embedding struct.
