### PR TITLE
Allow wrapping of PackageContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -82,7 +82,7 @@ type Context struct {
 	ignoreUnknownModuleTypes bool
 
 	// set during PrepareBuildActions
-	pkgNames        map[*PackageContext]string
+	pkgNames        map[*packageContext]string
 	globalVariables map[Variable]*ninjaString
 	globalPools     map[Pool]*poolDef
 	globalRules     map[Rule]*ruleDef
@@ -1919,13 +1919,13 @@ func (c *Context) setNinjaBuildDir(value *ninjaString) {
 }
 
 func (c *Context) makeUniquePackageNames(
-	liveGlobals *liveTracker) map[*PackageContext]string {
+	liveGlobals *liveTracker) map[*packageContext]string {
 
-	pkgs := make(map[string]*PackageContext)
-	pkgNames := make(map[*PackageContext]string)
-	longPkgNames := make(map[*PackageContext]bool)
+	pkgs := make(map[string]*packageContext)
+	pkgNames := make(map[*packageContext]string)
+	longPkgNames := make(map[*packageContext]bool)
 
-	processPackage := func(pctx *PackageContext) {
+	processPackage := func(pctx *packageContext) {
 		if pctx == nil {
 			// This is a built-in rule and has no package.
 			return
@@ -1972,7 +1972,7 @@ func (c *Context) makeUniquePackageNames(
 }
 
 func (c *Context) checkForVariableReferenceCycles(
-	variables map[Variable]*ninjaString, pkgNames map[*PackageContext]string) {
+	variables map[Variable]*ninjaString, pkgNames map[*packageContext]string) {
 
 	visited := make(map[Variable]bool)  // variables that were already checked
 	checking := make(map[Variable]bool) // variables actively being checked
@@ -2313,11 +2313,11 @@ func (c *Context) writeBuildDir(nw *ninjaWriter) error {
 }
 
 type globalEntity interface {
-	fullName(pkgNames map[*PackageContext]string) string
+	fullName(pkgNames map[*packageContext]string) string
 }
 
 type globalEntitySorter struct {
-	pkgNames map[*PackageContext]string
+	pkgNames map[*packageContext]string
 	entities []globalEntity
 }
 

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -137,9 +137,9 @@ type ModuleContext interface {
 
 	ModuleSubDir() string
 
-	Variable(pctx *PackageContext, name, value string)
-	Rule(pctx *PackageContext, name string, params RuleParams, argNames ...string) Rule
-	Build(pctx *PackageContext, params BuildParams)
+	Variable(pctx PackageContext, name, value string)
+	Rule(pctx PackageContext, name string, params RuleParams, argNames ...string) Rule
+	Build(pctx PackageContext, params BuildParams)
 
 	AddNinjaFileDeps(deps ...string)
 
@@ -267,7 +267,7 @@ func (m *moduleContext) ModuleSubDir() string {
 	return m.module.variantName
 }
 
-func (m *moduleContext) Variable(pctx *PackageContext, name, value string) {
+func (m *moduleContext) Variable(pctx PackageContext, name, value string) {
 	m.scope.ReparentTo(pctx)
 
 	v, err := m.scope.AddLocalVariable(name, value)
@@ -278,7 +278,7 @@ func (m *moduleContext) Variable(pctx *PackageContext, name, value string) {
 	m.actionDefs.variables = append(m.actionDefs.variables, v)
 }
 
-func (m *moduleContext) Rule(pctx *PackageContext, name string,
+func (m *moduleContext) Rule(pctx PackageContext, name string,
 	params RuleParams, argNames ...string) Rule {
 
 	m.scope.ReparentTo(pctx)
@@ -293,7 +293,7 @@ func (m *moduleContext) Rule(pctx *PackageContext, name string,
 	return r
 }
 
-func (m *moduleContext) Build(pctx *PackageContext, params BuildParams) {
+func (m *moduleContext) Build(pctx PackageContext, params BuildParams) {
 	m.scope.ReparentTo(pctx)
 
 	def, err := parseBuildParams(m.scope, &params)

--- a/ninja_defs.go
+++ b/ninja_defs.go
@@ -207,7 +207,7 @@ func parseRuleParams(scope scope, params *RuleParams) (*ruleDef,
 }
 
 func (r *ruleDef) WriteTo(nw *ninjaWriter, name string,
-	pkgNames map[*PackageContext]string) error {
+	pkgNames map[*packageContext]string) error {
 
 	if r.Comment != "" {
 		err := nw.Comment(r.Comment)
@@ -327,7 +327,7 @@ func parseBuildParams(scope scope, params *BuildParams) (*buildDef,
 	return b, nil
 }
 
-func (b *buildDef) WriteTo(nw *ninjaWriter, pkgNames map[*PackageContext]string) error {
+func (b *buildDef) WriteTo(nw *ninjaWriter, pkgNames map[*packageContext]string) error {
 	var (
 		comment       = b.Comment
 		rule          = b.Rule.fullName(pkgNames)
@@ -372,7 +372,7 @@ func (b *buildDef) WriteTo(nw *ninjaWriter, pkgNames map[*PackageContext]string)
 	return nw.BlankLine()
 }
 
-func valueList(list []*ninjaString, pkgNames map[*PackageContext]string,
+func valueList(list []*ninjaString, pkgNames map[*packageContext]string,
 	escaper *strings.Replacer) []string {
 
 	result := make([]string, len(list))

--- a/ninja_strings.go
+++ b/ninja_strings.go
@@ -258,11 +258,11 @@ func parseNinjaStrings(scope scope, strs []string) ([]*ninjaString,
 	return result, nil
 }
 
-func (n *ninjaString) Value(pkgNames map[*PackageContext]string) string {
+func (n *ninjaString) Value(pkgNames map[*packageContext]string) string {
 	return n.ValueWithEscaper(pkgNames, defaultEscaper)
 }
 
-func (n *ninjaString) ValueWithEscaper(pkgNames map[*PackageContext]string,
+func (n *ninjaString) ValueWithEscaper(pkgNames map[*packageContext]string,
 	escaper *strings.Replacer) string {
 
 	str := escaper.Replace(n.strings[0])

--- a/scope.go
+++ b/scope.go
@@ -25,9 +25,9 @@ import (
 // to the output .ninja file.  A variable may contain references to other global
 // Ninja variables, but circular variable references are not allowed.
 type Variable interface {
-	packageContext() *PackageContext
+	packageContext() *packageContext
 	name() string                                        // "foo"
-	fullName(pkgNames map[*PackageContext]string) string // "pkg.foo" or "path.to.pkg.foo"
+	fullName(pkgNames map[*packageContext]string) string // "pkg.foo" or "path.to.pkg.foo"
 	value(config interface{}) (*ninjaString, error)
 	String() string
 }
@@ -35,9 +35,9 @@ type Variable interface {
 // A Pool represents a Ninja pool that will be written to the output .ninja
 // file.
 type Pool interface {
-	packageContext() *PackageContext
+	packageContext() *packageContext
 	name() string                                        // "foo"
-	fullName(pkgNames map[*PackageContext]string) string // "pkg.foo" or "path.to.pkg.foo"
+	fullName(pkgNames map[*packageContext]string) string // "pkg.foo" or "path.to.pkg.foo"
 	def(config interface{}) (*poolDef, error)
 	String() string
 }
@@ -45,9 +45,9 @@ type Pool interface {
 // A Rule represents a Ninja build rule that will be written to the output
 // .ninja file.
 type Rule interface {
-	packageContext() *PackageContext
+	packageContext() *packageContext
 	name() string                                        // "foo"
-	fullName(pkgNames map[*PackageContext]string) string // "pkg.foo" or "path.to.pkg.foo"
+	fullName(pkgNames map[*packageContext]string) string // "pkg.foo" or "path.to.pkg.foo"
 	def(config interface{}) (*ruleDef, error)
 	scope() *basicScope
 	isArg(argName string) bool
@@ -260,8 +260,8 @@ func newLocalScope(parent *basicScope, namePrefix string) *localScope {
 // package context.  This allows a ModuleContext and SingletonContext to call
 // a function defined in a different Go package and have that function retain
 // access to all of the package-scoped variables of its own package.
-func (s *localScope) ReparentTo(pctx *PackageContext) {
-	s.scope.parent = pctx.scope
+func (s *localScope) ReparentTo(pctx PackageContext) {
+	s.scope.parent = pctx.getScope()
 }
 
 func (s *localScope) LookupVariable(name string) (Variable, error) {
@@ -354,7 +354,7 @@ type localVariable struct {
 	value_     *ninjaString
 }
 
-func (l *localVariable) packageContext() *PackageContext {
+func (l *localVariable) packageContext() *packageContext {
 	return nil
 }
 
@@ -362,7 +362,7 @@ func (l *localVariable) name() string {
 	return l.name_
 }
 
-func (l *localVariable) fullName(pkgNames map[*PackageContext]string) string {
+func (l *localVariable) fullName(pkgNames map[*packageContext]string) string {
 	return l.namePrefix + l.name_
 }
 
@@ -382,7 +382,7 @@ type localRule struct {
 	scope_     *basicScope
 }
 
-func (l *localRule) packageContext() *PackageContext {
+func (l *localRule) packageContext() *packageContext {
 	return nil
 }
 
@@ -390,7 +390,7 @@ func (l *localRule) name() string {
 	return l.name_
 }
 
-func (l *localRule) fullName(pkgNames map[*PackageContext]string) string {
+func (l *localRule) fullName(pkgNames map[*packageContext]string) string {
 	return l.namePrefix + l.name_
 }
 

--- a/singleton_ctx.go
+++ b/singleton_ctx.go
@@ -32,15 +32,15 @@ type SingletonContext interface {
 	ModuleErrorf(module Module, format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 
-	Variable(pctx *PackageContext, name, value string)
-	Rule(pctx *PackageContext, name string, params RuleParams, argNames ...string) Rule
-	Build(pctx *PackageContext, params BuildParams)
+	Variable(pctx PackageContext, name, value string)
+	Rule(pctx PackageContext, name string, params RuleParams, argNames ...string) Rule
+	Build(pctx PackageContext, params BuildParams)
 	RequireNinjaVersion(major, minor, micro int)
 
 	// SetNinjaBuildDir sets the value of the top-level "builddir" Ninja variable
 	// that controls where Ninja stores its build log files.  This value can be
 	// set at most one time for a single build, later calls are ignored.
-	SetNinjaBuildDir(pctx *PackageContext, value string)
+	SetNinjaBuildDir(pctx PackageContext, value string)
 
 	VisitAllModules(visit func(Module))
 	VisitAllModulesIf(pred func(Module) bool, visit func(Module))
@@ -96,7 +96,7 @@ func (s *singletonContext) Errorf(format string, args ...interface{}) {
 	s.errs = append(s.errs, fmt.Errorf(format, args...))
 }
 
-func (s *singletonContext) Variable(pctx *PackageContext, name, value string) {
+func (s *singletonContext) Variable(pctx PackageContext, name, value string) {
 	s.scope.ReparentTo(pctx)
 
 	v, err := s.scope.AddLocalVariable(name, value)
@@ -107,7 +107,7 @@ func (s *singletonContext) Variable(pctx *PackageContext, name, value string) {
 	s.actionDefs.variables = append(s.actionDefs.variables, v)
 }
 
-func (s *singletonContext) Rule(pctx *PackageContext, name string,
+func (s *singletonContext) Rule(pctx PackageContext, name string,
 	params RuleParams, argNames ...string) Rule {
 
 	s.scope.ReparentTo(pctx)
@@ -122,7 +122,7 @@ func (s *singletonContext) Rule(pctx *PackageContext, name string,
 	return r
 }
 
-func (s *singletonContext) Build(pctx *PackageContext, params BuildParams) {
+func (s *singletonContext) Build(pctx PackageContext, params BuildParams) {
 	s.scope.ReparentTo(pctx)
 
 	def, err := parseBuildParams(s.scope, &params)
@@ -137,7 +137,7 @@ func (s *singletonContext) RequireNinjaVersion(major, minor, micro int) {
 	s.context.requireNinjaVersion(major, minor, micro)
 }
 
-func (s *singletonContext) SetNinjaBuildDir(pctx *PackageContext, value string) {
+func (s *singletonContext) SetNinjaBuildDir(pctx PackageContext, value string) {
 	s.scope.ReparentTo(pctx)
 
 	ninjaValue, err := parseNinjaString(s.scope, value)


### PR DESCRIPTION
Turn PackageContext into an interface so that build systems can wrap it
to add more custom helpers.

This does introduce an API change, though it should be fairly simple.
NewPackageContext used to provide an opaque *PackageContext struct, now it
provides a PackageContext interface.