### PR TITLE
Allow primary builder to handle missing dependencies

### DIFF
--- a/context.go
+++ b/context.go
@@ -81,6 +81,9 @@ type Context struct {
 	// set by SetIgnoreUnknownModuleTypes
 	ignoreUnknownModuleTypes bool
 
+	// set by SetAllowMissingDependencies
+	allowMissingDependencies bool
+
 	// set during PrepareBuildActions
 	pkgNames        map[*packageContext]string
 	globalVariables map[Variable]*ninjaString
@@ -137,7 +140,8 @@ type moduleInfo struct {
 	moduleProperties []interface{}
 
 	// set during ResolveDependencies
-	directDeps []*moduleInfo
+	directDeps  []*moduleInfo
+	missingDeps []string
 
 	// set during updateDependencies
 	reverseDeps []*moduleInfo
@@ -435,6 +439,14 @@ func (c *Context) RegisterEarlyMutator(name string, mutator EarlyMutator) {
 // bootstrapping process.
 func (c *Context) SetIgnoreUnknownModuleTypes(ignoreUnknownModuleTypes bool) {
 	c.ignoreUnknownModuleTypes = ignoreUnknownModuleTypes
+}
+
+// SetAllowMissingDependencies changes the behavior of Blueprint to ignore
+// unresolved dependencies.  If the module's GenerateBuildActions calls
+// ModuleContext.GetMissingDependencies Blueprint will not emit any errors
+// for missing dependencies.
+func (c *Context) SetAllowMissingDependencies(allowMissingDependencies bool) {
+	c.allowMissingDependencies = allowMissingDependencies
 }
 
 // Parse parses a single Blueprints file from r, creating Module objects for
@@ -1121,6 +1133,10 @@ func (c *Context) addDependency(module *moduleInfo, depName string) []error {
 
 	depInfo, ok := c.moduleGroups[depName]
 	if !ok {
+		if c.allowMissingDependencies {
+			module.missingDeps = append(module.missingDeps, depName)
+			return nil
+		}
 		return []error{&Error{
 			Err: fmt.Errorf("%q depends on undefined module %q",
 				module.properties.Name, depName),
@@ -1181,6 +1197,10 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 
 	depInfo, ok := c.moduleGroups[depName]
 	if !ok {
+		if c.allowMissingDependencies {
+			module.missingDeps = append(module.missingDeps, depName)
+			return nil
+		}
 		return []error{&Error{
 			Err: fmt.Errorf("%q depends on undefined module %q",
 				module.properties.Name, depName),
@@ -1674,13 +1694,27 @@ func (c *Context) generateModuleBuildActions(config interface{},
 				config:  config,
 				module:  module,
 			},
-			scope: scope,
+			scope:              scope,
+			handledMissingDeps: module.missingDeps == nil,
 		}
 
 		mctx.module.logicModule.GenerateBuildActions(mctx)
 
 		if len(mctx.errs) > 0 {
 			errsCh <- mctx.errs
+			return true
+		}
+
+		if module.missingDeps != nil && !mctx.handledMissingDeps {
+			var errs []error
+			for _, depName := range module.missingDeps {
+				errs = append(errs, &Error{
+					Err: fmt.Errorf("%q depends on undefined module %q",
+						module.properties.Name, depName),
+					Pos: module.pos,
+				})
+			}
+			errsCh <- errs
 			return true
 		}
 

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -146,6 +146,8 @@ type ModuleContext interface {
 	PrimaryModule() Module
 	FinalModule() Module
 	VisitAllModuleVariants(visit func(Module))
+
+	GetMissingDependencies() []string
 }
 
 var _ BaseModuleContext = (*baseModuleContext)(nil)
@@ -221,9 +223,10 @@ var _ ModuleContext = (*moduleContext)(nil)
 
 type moduleContext struct {
 	baseModuleContext
-	scope         *localScope
-	ninjaFileDeps []string
-	actionDefs    localBuildActions
+	scope              *localScope
+	ninjaFileDeps      []string
+	actionDefs         localBuildActions
+	handledMissingDeps bool
 }
 
 func (m *moduleContext) OtherModuleName(logicModule Module) string {
@@ -320,6 +323,11 @@ func (m *moduleContext) VisitAllModuleVariants(visit func(Module)) {
 	for _, module := range m.module.group.modules {
 		visit(module.logicModule)
 	}
+}
+
+func (m *moduleContext) GetMissingDependencies() []string {
+	m.handledMissingDeps = true
+	return m.module.missingDeps
 }
 
 //


### PR DESCRIPTION
In some cases the primary builder may need to handle missing
dependencies.  Add Context.SetAllowMissingDependencies to cause
Blueprint to store the list of missing dependencies without immediately
emitting an error, and ModuleContext.GetMissingDependencies to return
the missing dependencies to the primary builder.  If the primary builder
does not call ModuleContext.GetMissingDependencies Blueprint will emit
dependency errors.