### PR TITLE
Add ModuleSubDir to Context and SingletonContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -2114,6 +2114,11 @@ func (c *Context) ModuleDir(logicModule Module) string {
 	return filepath.Dir(module.relBlueprintsFile)
 }
 
+func (c *Context) ModuleSubDir(logicModule Module) string {
+	module := c.moduleInfo[logicModule]
+	return module.variantName
+}
+
 func (c *Context) BlueprintFile(logicModule Module) string {
 	module := c.moduleInfo[logicModule]
 	return module.relBlueprintsFile

--- a/singleton_ctx.go
+++ b/singleton_ctx.go
@@ -27,6 +27,7 @@ type SingletonContext interface {
 
 	ModuleName(module Module) string
 	ModuleDir(module Module) string
+	ModuleSubDir(module Module) string
 	BlueprintFile(module Module) string
 
 	ModuleErrorf(module Module, format string, args ...interface{})
@@ -80,6 +81,10 @@ func (s *singletonContext) ModuleName(logicModule Module) string {
 
 func (s *singletonContext) ModuleDir(logicModule Module) string {
 	return s.context.ModuleDir(logicModule)
+}
+
+func (s *singletonContext) ModuleSubDir(logicModule Module) string {
+	return s.context.ModuleSubDir(logicModule)
 }
 
 func (s *singletonContext) BlueprintFile(logicModule Module) string {


### PR DESCRIPTION
Singletons may need ModuleSubDir, for example to implement a stable sort
on modules.  Add ModuleSubDir to SingletonContext and Context.