### PR TITLE
docs: Allow propery structs to contain non-struct ptrs

### DIFF
--- a/bootstrap/bpdoc/bpdoc.go
+++ b/bootstrap/bpdoc/bpdoc.go
@@ -501,13 +501,11 @@ func nestedPropertyStructs(s reflect.Value) map[string]reflect.Value {
 						}
 						elem = elem.Elem()
 					}
-					if elem.Kind() != reflect.Struct {
-						panic(fmt.Errorf("can't get type of field %q: points to a "+
-							"non-struct", field.Name))
+					if elem.Kind() == reflect.Struct {
+						nestPoint := prefix + proptools.PropertyNameForField(field.Name)
+						ret[nestPoint] = elem
+						walk(elem, nestPoint+".")
 					}
-					nestPoint := prefix + proptools.PropertyNameForField(field.Name)
-					ret[nestPoint] = elem
-					walk(elem, nestPoint+".")
 				}
 			default:
 				panic(fmt.Errorf("unexpected kind for property struct field %q: %s",


### PR DESCRIPTION
Other parts of blueprint have started allowing pointers to strings and
booleans. This code silently allowed them because of the nil check, but
it doesn't work if the module factory sets a default value.