### PR TITLE
walkDeps: Fixed bug on non-walked, visited deps.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1940,10 +1940,9 @@ func (c *Context) walkDeps(topModule *moduleInfo,
 
 	var walk func(module *moduleInfo)
 	walk = func(module *moduleInfo) {
-		visited[module] = true
-
 		for _, moduleDep := range module.directDeps {
 			if !visited[moduleDep] {
+				visited[moduleDep] = true
 				visiting = moduleDep
 				if visit(moduleDep.logicModule, module.logicModule) {
 					walk(moduleDep)


### PR DESCRIPTION
visited map was not being updated when the dependency was being
visited, only if it was being walked. This led to cases where
duplicate traversals were possible.