### PR TITLE
walkDeps: Fixed bug with the visit nodes.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1926,7 +1926,7 @@ func (c *Context) processLocalBuildActions(out, in *localBuildActions,
 }
 
 func (c *Context) walkDeps(topModule *moduleInfo,
-	visit func(Module, Module) bool) {
+	visit func(Module, Module) (bool, bool)) {
 
 	visited := make(map[*moduleInfo]bool)
 	var visiting *moduleInfo
@@ -1942,9 +1942,12 @@ func (c *Context) walkDeps(topModule *moduleInfo,
 	walk = func(module *moduleInfo) {
 		for _, moduleDep := range module.directDeps {
 			if !visited[moduleDep] {
-				visited[moduleDep] = true
 				visiting = moduleDep
-				if visit(moduleDep.logicModule, module.logicModule) {
+				didVisit, shouldWalk := visit(moduleDep.logicModule, module.logicModule)
+				if didVisit {
+					visited[moduleDep] = true
+				}
+				if shouldWalk {
 					walk(moduleDep)
 				}
 			}

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -134,7 +134,7 @@ type ModuleContext interface {
 	VisitDirectDepsIf(pred func(Module) bool, visit func(Module))
 	VisitDepsDepthFirst(visit func(Module))
 	VisitDepsDepthFirstIf(pred func(Module) bool, visit func(Module))
-	WalkDeps(visit func(Module, Module) bool)
+	WalkDeps(visit func(Module, Module) (bool, bool))
 
 	ModuleSubDir() string
 
@@ -269,7 +269,7 @@ func (m *moduleContext) VisitDepsDepthFirstIf(pred func(Module) bool,
 	m.context.visitDepsDepthFirstIf(m.module, pred, visit)
 }
 
-func (m *moduleContext) WalkDeps(visit func(Module, Module) bool) {
+func (m *moduleContext) WalkDeps(visit func(Module, Module) (bool, bool)) {
 	m.context.walkDeps(m.module, visit)
 }
 
@@ -368,7 +368,7 @@ type TopDownMutatorContext interface {
 	VisitDirectDepsIf(pred func(Module) bool, visit func(Module))
 	VisitDepsDepthFirst(visit func(Module))
 	VisitDepsDepthFirstIf(pred func(Module) bool, visit func(Module))
-	WalkDeps(visit func(Module, Module) bool)
+	WalkDeps(visit func(Module, Module) (bool, bool))
 }
 
 type BottomUpMutatorContext interface {
@@ -547,6 +547,6 @@ func (mctx *mutatorContext) VisitDepsDepthFirstIf(pred func(Module) bool,
 	mctx.context.visitDepsDepthFirstIf(mctx.module, pred, visit)
 }
 
-func (mctx *mutatorContext) WalkDeps(visit func(Module, Module) bool) {
+func (mctx *mutatorContext) WalkDeps(visit func(Module, Module) (bool, bool)) {
 	mctx.context.walkDeps(mctx.module, visit)
 }


### PR DESCRIPTION
The last fix actually introduced a new bug. The problem was that it
changed the meaning of visit()'s return value from whether the node
was visited to whether the node's dependencies should be walked. In
actuality, we need a way to express both of these meanings.

This breaks the API for walkDeps, but was anyone else actually
using this function?
