### PR TITLE
Fix package names for executables.

### DIFF
--- a/choosestage/choosestage.go
+++ b/choosestage/choosestage.go
@@ -29,7 +29,7 @@
 // The timestamp of the first file is not updated so that it can be regenerated
 // with any local changes.
 
-package choosestage
+package main
 
 import (
 	"bytes"

--- a/gotestmain/gotestmain.go
+++ b/gotestmain/gotestmain.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gotestmain
+package main
 
 import (
 	"bytes"


### PR DESCRIPTION
Go 1.6 fixed a bug where compiling with the -pack flag allowed non-main
packages to link.
https://github.com/golang/go/issues/13468

This change uses package main for choosestage and gotestmain.