### PR TITLE
Add SingletonContext.Eval to evaluate ninja strings

### DIFF
--- a/context.go
+++ b/context.go
@@ -1846,6 +1846,7 @@ func (c *Context) generateSingletonBuildActions(config interface{},
 			context: c,
 			config:  config,
 			scope:   scope,
+			globals: liveGlobals,
 		}
 
 		func() {


### PR DESCRIPTION
Our use case is to write out some configuration variables to give to our
legacy build system. But in order to do that, we either need to keep a
Go copy of all of the configuration, and still have all the calls to
convert them to ninja variables, or evaluate our ninja variables.