### PR TITLE
Add blueprint_go_binary for user-run tools

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -117,13 +117,13 @@ bootstrap_core_go_binary(
     srcs = ["bootstrap/minibp/main.go"],
 )
 
-bootstrap_go_binary(
+blueprint_go_binary(
     name = "bpfmt",
     deps = ["blueprint-parser"],
     srcs = ["bpfmt/bpfmt.go"],
 )
 
-bootstrap_go_binary(
+blueprint_go_binary(
     name = "bpmodify",
     deps = ["blueprint-parser"],
     srcs = ["bpmodify/bpmodify.go"],

--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -94,6 +94,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	ctx.RegisterModuleType("bootstrap_go_package", newGoPackageModuleFactory(bootstrapConfig))
 	ctx.RegisterModuleType("bootstrap_core_go_binary", newGoBinaryModuleFactory(bootstrapConfig, StageBootstrap))
 	ctx.RegisterModuleType("bootstrap_go_binary", newGoBinaryModuleFactory(bootstrapConfig, StagePrimary))
+	ctx.RegisterModuleType("blueprint_go_binary", newGoBinaryModuleFactory(bootstrapConfig, StageMain))
 	ctx.RegisterTopDownMutator("bootstrap_stage", propagateStageBootstrap)
 	ctx.RegisterSingletonType("bootstrap", newSingletonFactory(bootstrapConfig))
 

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -44,6 +44,13 @@ type ConfigRemoveAbandonedFiles interface {
 	RemoveAbandonedFiles() bool
 }
 
+type ConfigBlueprintToolLocation interface {
+	// BlueprintToolLocation can return a path name to install blueprint tools
+	// designed for end users (bpfmt, bpmodify, and anything else using
+	// blueprint_go_binary).
+	BlueprintToolLocation() string
+}
+
 type Stage int
 
 const (


### PR DESCRIPTION
Move these tools from $buildDir/.bootstrap/bin to $buildDir/bin
(configurable by the primary builder).

Also delay building them until the main stage, and give them a phony
target "blueprint_tools".