### PR TITLE
bpdoc improvements

### DIFF
--- a/bootstrap/bpdoc/bpdoc.go
+++ b/bootstrap/bpdoc/bpdoc.go
@@ -263,7 +263,12 @@ func structProperties(structType *ast.StructType) (props []Property, err error) 
 					return nil, err
 				}
 			}
-			switch a := f.Type.(type) {
+
+			t := f.Type
+			if star, ok := t.(*ast.StarExpr); ok {
+				t = star.X
+			}
+			switch a := t.(type) {
 			case *ast.ArrayType:
 				typ = "list of strings"
 			case *ast.InterfaceType:

--- a/package_ctx.go
+++ b/package_ctx.go
@@ -96,7 +96,7 @@ func NewPackageContext(pkgPath string) PackageContext {
 	checkCalledFromInit()
 
 	if _, present := packageContexts[pkgPath]; present {
-		panic(fmt.Errorf("package %q already has a package context"))
+		panic(fmt.Errorf("package %q already has a package context", pkgPath))
 	}
 
 	pkgName := pkgPathToName(pkgPath)

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -224,7 +224,7 @@ var validUnpackTestCases = []struct {
 		[]error{
 			&Error{
 				Err: fmt.Errorf("filtered field nested.foo cannot be set in a Blueprint file"),
-				Pos: scanner.Position{"", 27, 4, 8},
+				Pos: mkpos(27, 4, 8),
 			},
 		},
 	},
@@ -397,5 +397,13 @@ func TestUnpackProperties(t *testing.T) {
 			t.Errorf("  expected: %+v", testCase.output)
 			t.Errorf("       got: %+v", output)
 		}
+	}
+}
+
+func mkpos(offset, line, column int) scanner.Position {
+	return scanner.Position{
+		Offset: offset,
+		Line:   line,
+		Column: column,
 	}
 }


### PR DESCRIPTION
Improve readability in bpdoc by removing naming stutter.

Fixes the documented type for properties stored in pointers, previously printed as "Type: *ast.StarExpr"