### PR TITLE
Allow tests to mock filesystem

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -8,6 +8,7 @@ bootstrap_go_package(
     pkgPath = "github.com/google/blueprint",
     srcs = [
         "context.go",
+        "fs.go",
         "live_tracker.go",
         "mangle.go",
         "module_ctx.go",

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -60,8 +60,8 @@ rule g.bootstrap.link
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint/pkg/github.com/google/blueprint.a $
         : g.bootstrap.compile ${g.bootstrap.srcDir}/context.go $
-        ${g.bootstrap.srcDir}/live_tracker.go ${g.bootstrap.srcDir}/mangle.go $
-        ${g.bootstrap.srcDir}/module_ctx.go $
+        ${g.bootstrap.srcDir}/fs.go ${g.bootstrap.srcDir}/live_tracker.go $
+        ${g.bootstrap.srcDir}/mangle.go ${g.bootstrap.srcDir}/module_ctx.go $
         ${g.bootstrap.srcDir}/ninja_defs.go $
         ${g.bootstrap.srcDir}/ninja_strings.go $
         ${g.bootstrap.srcDir}/ninja_writer.go $
@@ -81,7 +81,7 @@ default $
 # Variant:
 # Type:    bootstrap_go_package
 # Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
-# Defined: Blueprints:80:1
+# Defined: Blueprints:81:1
 
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap/pkg/github.com/google/blueprint/bootstrap.a $
@@ -108,7 +108,7 @@ default $
 # Variant:
 # Type:    bootstrap_go_package
 # Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
-# Defined: Blueprints:99:1
+# Defined: Blueprints:100:1
 
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint-bootstrap-bpdoc/pkg/github.com/google/blueprint/bootstrap/bpdoc.a $
@@ -128,7 +128,7 @@ default $
 # Variant:
 # Type:    bootstrap_go_package
 # Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
-# Defined: Blueprints:46:1
+# Defined: Blueprints:47:1
 
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint-deptools/pkg/github.com/google/blueprint/deptools.a $
@@ -143,7 +143,7 @@ default $
 # Variant:
 # Type:    bootstrap_go_package
 # Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
-# Defined: Blueprints:31:1
+# Defined: Blueprints:32:1
 
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint-parser/pkg/github.com/google/blueprint/parser.a $
@@ -160,7 +160,7 @@ default $
 # Variant:
 # Type:    bootstrap_go_package
 # Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
-# Defined: Blueprints:52:1
+# Defined: Blueprints:53:1
 
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint-pathtools/pkg/github.com/google/blueprint/pathtools.a $
@@ -175,7 +175,7 @@ default $
 # Variant:
 # Type:    bootstrap_go_package
 # Factory: github.com/google/blueprint/bootstrap.newGoPackageModuleFactory.func1
-# Defined: Blueprints:64:1
+# Defined: Blueprints:65:1
 
 build $
         ${g.bootstrap.buildDir}/.bootstrap/blueprint-proptools/pkg/github.com/google/blueprint/proptools.a $
@@ -193,7 +193,7 @@ default $
 # Variant:
 # Type:    bootstrap_core_go_binary
 # Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
-# Defined: Blueprints:142:1
+# Defined: Blueprints:143:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/choosestage/obj/choosestage.a: $
         g.bootstrap.compile ${g.bootstrap.srcDir}/choosestage/choosestage.go | $
@@ -216,7 +216,7 @@ default ${g.bootstrap.BinDir}/choosestage
 # Variant:
 # Type:    bootstrap_core_go_binary
 # Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
-# Defined: Blueprints:132:1
+# Defined: Blueprints:133:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/gotestmain/obj/gotestmain.a: $
         g.bootstrap.compile ${g.bootstrap.srcDir}/gotestmain/gotestmain.go | $
@@ -239,7 +239,7 @@ default ${g.bootstrap.BinDir}/gotestmain
 # Variant:
 # Type:    bootstrap_core_go_binary
 # Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
-# Defined: Blueprints:137:1
+# Defined: Blueprints:138:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/gotestrunner/obj/gotestrunner.a: $
         g.bootstrap.compile ${g.bootstrap.srcDir}/gotestrunner/gotestrunner.go $
@@ -262,7 +262,7 @@ default ${g.bootstrap.BinDir}/gotestrunner
 # Variant:
 # Type:    bootstrap_core_go_binary
 # Factory: github.com/google/blueprint/bootstrap.newGoBinaryModuleFactory.func1
-# Defined: Blueprints:111:1
+# Defined: Blueprints:112:1
 
 build ${g.bootstrap.buildDir}/.bootstrap/minibp/obj/minibp.a: $
         g.bootstrap.compile ${g.bootstrap.srcDir}/bootstrap/minibp/main.go | $

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blueprint
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// Based on Andrew Gerrand's "10 things you (probably) dont' know about Go"
+
+var fs fileSystem = osFS{}
+
+type fileSystem interface {
+	Open(name string) (io.ReadCloser, error)
+	Exists(name string) (bool, bool, error)
+}
+
+// osFS implements fileSystem using the local disk.
+type osFS struct{}
+
+func (osFS) Open(name string) (io.ReadCloser, error) { return os.Open(name) }
+func (osFS) Exists(name string) (bool, bool, error) {
+	stat, err := os.Stat(name)
+	if err == nil {
+		return true, stat.IsDir(), nil
+	} else if os.IsNotExist(err) {
+		return false, false, nil
+	} else {
+		return false, false, err
+	}
+}
+
+type mockFS struct {
+	files map[string][]byte
+}
+
+func (m mockFS) Open(name string) (io.ReadCloser, error) {
+	if f, ok := m.files[name]; ok {
+		return struct {
+			io.Closer
+			*bytes.Reader
+		}{
+			ioutil.NopCloser(nil),
+			bytes.NewReader(f),
+		}, nil
+	}
+
+	return nil, &os.PathError{
+		Op:   "open",
+		Path: name,
+		Err:  os.ErrNotExist,
+	}
+}
+
+func (m mockFS) Exists(name string) (bool, bool, error) {
+	_, ok := m.files[name]
+	return ok, false, nil
+}


### PR DESCRIPTION
Tests can call Context.MockFileSystem to pass in a map of filenames to
contents.

Change-Id: Idd67c68f7cb43bc2117cc78336347db7e2f21991
