### PR TITLE
printer: support multiple skipped comments

### DIFF
--- a/parser/printer_test.go
+++ b/parser/printer_test.go
@@ -296,6 +296,22 @@ test {}
 // Comment
 `,
 	},
+	{
+		input: `
+test // test
+
+// test
+{
+}
+`,
+		output: `
+test { // test
+
+// test
+
+}
+`,
+	},
 }
 
 func TestPrinter(t *testing.T) {


### PR DESCRIPTION
There may be multiple skipped comments in a row, convert
p.skippedComments to a list and add a test.

Change-Id: I30dcff269bee56fd51ef9513dab7c7885c44b7d7