### PR TITLE
Expose ModuleType to Singletons

### DIFF
--- a/context.go
+++ b/context.go
@@ -2366,6 +2366,11 @@ func (c *Context) ModuleSubDir(logicModule Module) string {
 	return module.variantName
 }
 
+func (c *Context) ModuleType(logicModule Module) string {
+	module := c.moduleInfo[logicModule]
+	return module.typeName
+}
+
 func (c *Context) BlueprintFile(logicModule Module) string {
 	module := c.moduleInfo[logicModule]
 	return module.relBlueprintsFile

--- a/singleton_ctx.go
+++ b/singleton_ctx.go
@@ -28,6 +28,7 @@ type SingletonContext interface {
 	ModuleName(module Module) string
 	ModuleDir(module Module) string
 	ModuleSubDir(module Module) string
+	ModuleType(module Module) string
 	BlueprintFile(module Module) string
 
 	ModuleErrorf(module Module, format string, args ...interface{})
@@ -91,6 +92,10 @@ func (s *singletonContext) ModuleDir(logicModule Module) string {
 
 func (s *singletonContext) ModuleSubDir(logicModule Module) string {
 	return s.context.ModuleSubDir(logicModule)
+}
+
+func (s *singletonContext) ModuleType(logicModule Module) string {
+	return s.context.ModuleType(logicModule)
 }
 
 func (s *singletonContext) BlueprintFile(logicModule Module) string {


### PR DESCRIPTION
In order to implement some build statistics in Soong, expose the module
type (the string used to define the module) to singletons.