### PR TITLE
Add dependency visiting methods to BottomUpMutatorContext

### DIFF
--- a/module_ctx.go
+++ b/module_ctx.go
@@ -414,7 +414,7 @@ type TopDownMutatorContext interface {
 }
 
 type BottomUpMutatorContext interface {
-	baseMutatorContext
+	TopDownMutatorContext
 
 	AddDependency(module Module, tag DependencyTag, name ...string)
 	AddReverseDependency(module Module, tag DependencyTag, name string)


### PR DESCRIPTION
It can be useful for a BottomUpMutator to visit its dependencies.  Embed
all of TopDownMutatorContext into BottomUpMutatorContext.

Change-Id: I7c7262fbe3d8fa9cc0d26899eee704cc862835df