### PR TITLE
Enforce gofmt in travis

### DIFF
--- a/.travis.gofmt.sh
+++ b/.travis.gofmt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -n "$(gofmt -l .)" ]; then
+    echo "Go code is not formatted:"
+    gofmt -d .
+    exit 1
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
     - source .travis.fix-fork.sh
 
 script:
+    - ./.travis.gofmt.sh
     - go test ./...
     - mkdir stage
     - cd stage

--- a/ninja_defs.go
+++ b/ninja_defs.go
@@ -265,7 +265,7 @@ func parseBuildParams(scope scope, params *BuildParams) (*buildDef,
 
 	b := &buildDef{
 		Comment: comment,
-		Rule: rule,
+		Rule:    rule,
 	}
 
 	if !scope.IsRuleVisible(rule) {


### PR DESCRIPTION
Run gofmt -l . during travis to catch pull requests that have not had
gofmt run on them.

Change-Id: Ibfdf988a535d82721f3c4bc328b189f606f12778