### PR TITLE
Elide empty variations

### DIFF
--- a/context.go
+++ b/context.go
@@ -1000,10 +1000,12 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 		newModule.dependencyVariant = origModule.dependencyVariant.clone()
 		newModule.moduleProperties = newProperties
 
-		if newModule.variantName == "" {
-			newModule.variantName = variationName
-		} else {
-			newModule.variantName += "_" + variationName
+		if variationName != "" {
+			if newModule.variantName == "" {
+				newModule.variantName = variationName
+			} else {
+				newModule.variantName += "_" + variationName
+			}
 		}
 
 		newModules = append(newModules, newModule)


### PR DESCRIPTION
Don't add a "_" to the variant name if the variation name is empty.  For
example, when splitting a variant with name "foo" into variations "" and
"bar", the new variants would be named "foo" and "foo_bar" instead of
"foo_" and "foo_bar".

Change-Id: I82342d57e2a8e9f2d65a7d8d2872dcb7b3512899