### PR TITLE
Support structures built with StructOf

### DIFF
--- a/unpack.go
+++ b/unpack.go
@@ -128,6 +128,15 @@ func unpackStructValue(namePrefix string, structValue reflect.Value,
 		fieldValue := structValue.Field(i)
 		field := structType.Field(i)
 
+		// In Go 1.7, runtime-created structs are unexported, so it's not
+		// possible to create an exported anonymous field with a generated
+		// type. So workaround this by special-casing "BlueprintEmbed" to
+		// behave like an anonymous field for structure unpacking.
+		if field.Name == "BlueprintEmbed" {
+			field.Name = ""
+			field.Anonymous = true
+		}
+
 		if field.PkgPath != "" {
 			// This is an unexported field, so just skip it.
 			continue


### PR DESCRIPTION
In Go 1.7, all generated types (including StructOf) are marked as
unexported types. This is not a problem with regular named fields, since
the whether the field is exported is based on the name, not the type.
But for unnamed (anonymous) fields, there is no name, and it falls back
to whether the type is exported or not. When the field isn't exported,
we're unable to use reflection to set the value.

Special case fields named "BlueprintEmbed" to act like exported unnamed
fields during unpacking. There is no functionality lost here, since code
can not directly access these runtime generated fields.

Structures embedded in the source shouldn't be affected by this change,
unless they happen to use the "BlueprintEmbed" field, which is not a
normal field name due to the capitalization.