### PR TITLE
Fix missing dependencies on Blueprints

### DIFF
--- a/context.go
+++ b/context.go
@@ -821,6 +821,7 @@ func (c *Context) findBuildBlueprints(dir string, build []string,
 			}
 
 			blueprints = append(blueprints, foundBlueprints)
+			deps = append(deps, foundBlueprints)
 		}
 	}
 


### PR DESCRIPTION
This change adds dependencies on Blueprints defined by the 'build'
parameter. Previously, this was only done on Blueprints added with
the 'subdirs' parameter.