### PR TITLE
Add dependency on build= blueprint files

### DIFF
--- a/context.go
+++ b/context.go
@@ -821,6 +821,7 @@ func (c *Context) findBuildBlueprints(dir string, build []string,
 			}
 
 			blueprints = append(blueprints, foundBlueprints)
+			deps = append(deps, foundBlueprints)
 		}
 	}
 


### PR DESCRIPTION
Blueprint files included with build= statements were not adding a
dependency to cause regenerating when they were changed.

Bug: 32085516
Test: touch external/boringssl/sources.bp && mmma -j external/boringssl
Change-Id: Id4fdf3b6788ae5c1e94547dc63ec6b55424a66a0