### PR TITLE
Modify module name handling

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -192,7 +192,9 @@ func isBootstrapBinaryModule(module blueprint.Module) bool {
 
 // A goPackage is a module for building Go packages.
 type goPackage struct {
+	blueprint.SimpleName
 	properties struct {
+		Deps      []string
 		PkgPath   string
 		Srcs      []string
 		TestSrcs  []string
@@ -224,8 +226,12 @@ func newGoPackageModuleFactory(config *Config) func() (blueprint.Module, []inter
 			config: config,
 		}
 		module.properties.BuildStage = StageMain
-		return module, []interface{}{&module.properties}
+		return module, []interface{}{&module.properties, &module.SimpleName.Properties}
 	}
+}
+
+func (g *goPackage) DynamicDependencies(ctx blueprint.DynamicDependerModuleContext) []string {
+	return g.properties.Deps
 }
 
 func (g *goPackage) GoPkgPath() string {
@@ -314,7 +320,9 @@ func (g *goPackage) GenerateBuildActions(ctx blueprint.ModuleContext) {
 
 // A goBinary is a module for building executable binaries from Go sources.
 type goBinary struct {
+	blueprint.SimpleName
 	properties struct {
+		Deps           []string
 		Srcs           []string
 		TestSrcs       []string
 		PrimaryBuilder bool
@@ -336,8 +344,12 @@ func newGoBinaryModuleFactory(config *Config, buildStage Stage) func() (blueprin
 			config: config,
 		}
 		module.properties.BuildStage = buildStage
-		return module, []interface{}{&module.properties}
+		return module, []interface{}{&module.properties, &module.SimpleName.Properties}
 	}
+}
+
+func (g *goBinary) DynamicDependencies(ctx blueprint.DynamicDependerModuleContext) []string {
+	return g.properties.Deps
 }
 
 func (g *goBinary) GoTestTarget() string {

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -493,6 +493,7 @@ type BottomUpMutatorContext interface {
 	AddVariationDependencies([]Variation, DependencyTag, ...string)
 	AddFarVariationDependencies([]Variation, DependencyTag, ...string)
 	AddInterVariantDependency(tag DependencyTag, from, to Module)
+	ReplaceDependencies(string)
 }
 
 // A Mutator function is called for each Module, and can use
@@ -651,6 +652,13 @@ func (mctx *mutatorContext) AddFarVariationDependencies(variations []Variation, 
 
 func (mctx *mutatorContext) AddInterVariantDependency(tag DependencyTag, from, to Module) {
 	mctx.context.addInterVariantDependency(mctx.module, tag, from, to)
+}
+
+// ReplaceDependencies replaces all dependencies on the identical variant of the module with the
+// specified name with the current variant of this module.  Replacements don't take effect until
+// after the mutator pass is finished.
+func (mctx *mutatorContext) ReplaceDependencies(name string) {
+	mctx.context.replaceDependencies(mctx.module, name)
 }
 
 func (mctx *mutatorContext) OtherModuleExists(name string) bool {

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -457,6 +457,7 @@ type baseMutatorContext interface {
 	BaseModuleContext
 
 	OtherModuleExists(name string) bool
+	Rename(name string)
 	Module() Module
 }
 
@@ -654,6 +655,12 @@ func (mctx *mutatorContext) AddInterVariantDependency(tag DependencyTag, from, t
 
 func (mctx *mutatorContext) OtherModuleExists(name string) bool {
 	return mctx.context.moduleNames[name] != nil
+}
+
+// Rename all variants of a module.  The new name is not visible to calls to ModuleName,
+// AddDependency or OtherModuleName until after this mutator pass is complete.
+func (mctx *mutatorContext) Rename(name string) {
+	mctx.context.rename(mctx.module.group, name)
 }
 
 // SimpleName is an embeddable object to implement the ModuleContext.Name method using a property

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -456,6 +456,7 @@ type mutatorContext struct {
 type baseMutatorContext interface {
 	BaseModuleContext
 
+	OtherModuleExists(name string) bool
 	Module() Module
 }
 
@@ -649,6 +650,10 @@ func (mctx *mutatorContext) AddFarVariationDependencies(variations []Variation, 
 
 func (mctx *mutatorContext) AddInterVariantDependency(tag DependencyTag, from, to Module) {
 	mctx.context.addInterVariantDependency(mctx.module, tag, from, to)
+}
+
+func (mctx *mutatorContext) OtherModuleExists(name string) bool {
+	return mctx.context.moduleNames[name] != nil
 }
 
 // SimpleName is an embeddable object to implement the ModuleContext.Name method using a property

--- a/visit_test.go
+++ b/visit_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 type visitModule struct {
+	SimpleName
 	properties struct {
 		Visit                 []string
 		VisitDepsDepthFirst   string `blueprint:"mutated"`
@@ -31,7 +32,7 @@ type visitModule struct {
 
 func newVisitModule() (Module, []interface{}) {
 	m := &visitModule{}
-	return m, []interface{}{&m.properties}
+	return m, []interface{}{&m.properties, &m.SimpleName.Properties}
 }
 
 func (f *visitModule) GenerateBuildActions(ModuleContext) {
@@ -140,7 +141,7 @@ func setupVisitTest(t *testing.T) *Context {
 func TestVisit(t *testing.T) {
 	ctx := setupVisitTest(t)
 
-	topModule := ctx.moduleGroups["A"].modules[0].logicModule.(*visitModule)
+	topModule := ctx.modulesFromName("A")[0].logicModule.(*visitModule)
 	assertString(t, topModule.properties.VisitDepsDepthFirst, "EDCB")
 	assertString(t, topModule.properties.VisitDepsDepthFirstIf, "EDC")
 	assertString(t, topModule.properties.VisitDirectDeps, "B")


### PR DESCRIPTION
This patch set allows primary builders to have control over the name visible to Blueprint, to determine if a module with a name exists, to rename a module during a mutator, and to replace dependencies on a variant of module with another module.