### PR TITLE
Fix Soong glob regeneration and other bootstrap cleanups

### DIFF
--- a/blueprint.bash
+++ b/blueprint.bash
@@ -53,10 +53,10 @@ else
 fi
 
 # Build minibp and the primary build.ninja
-"${NINJA}" -w dupbuild=err -f "${BUILDDIR}/.minibootstrap/build.ninja" "${BUILDDIR}/.bootstrap/build.ninja"
+"${NINJA}" -w dupbuild=err -f "${BUILDDIR}/.minibootstrap/build.ninja"
 
 # Build the primary builder and the main build.ninja
-"${NINJA}" -w dupbuild=err -f "${BUILDDIR}/.bootstrap/build.ninja" "${BUILDDIR}/build.ninja"
+"${NINJA}" -w dupbuild=err -f "${BUILDDIR}/.bootstrap/build.ninja"
 
 # SKIP_NINJA can be used by wrappers that wish to run ninja themselves.
 if [ -z "$SKIP_NINJA" ]; then

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -270,9 +270,7 @@ default ${g.bootstrap.BinDir}/minibp
 # Factory:   github.com/google/blueprint/bootstrap.newSingletonFactory.func1
 
 build ${g.bootstrap.buildDir}/.bootstrap/build.ninja: g.bootstrap.build.ninja $
-        ${g.bootstrap.srcDir}/Blueprints | ${builder} $
-        ${g.bootstrap.BinDir}/gotestmain ${g.bootstrap.BinDir}/gotestrunner $
-        ${g.bootstrap.BinDir}/minibp ${g.bootstrap.srcDir}/Blueprints
+        ${g.bootstrap.srcDir}/Blueprints | ${builder}
     builder = ${g.bootstrap.BinDir}/minibp
     extra = --build-primary
 default ${g.bootstrap.buildDir}/.bootstrap/build.ninja

--- a/build.ninja.in
+++ b/build.ninja.in
@@ -30,6 +30,12 @@ rule g.bootstrap.bootstrap
     description = bootstrap ${in}
     generator = true
 
+rule g.bootstrap.build.ninja
+    command = ${builder} ${extra} -b ${g.bootstrap.buildDir} -d ${out}.d -o ${out} ${in}
+    depfile = ${out}.d
+    description = ${builder} ${out}
+    restat = true
+
 rule g.bootstrap.compile
     command = GOROOT='${g.bootstrap.goRoot}' ${g.bootstrap.compileCmd} -o ${out} -p ${pkgPath} -complete ${incFlags} -pack ${in}
     description = compile ${out}
@@ -263,26 +269,18 @@ default ${g.bootstrap.BinDir}/minibp
 # Singleton: bootstrap
 # Factory:   github.com/google/blueprint/bootstrap.newSingletonFactory.func1
 
-rule s.bootstrap.primarybp
-    command = ${g.bootstrap.BinDir}/minibp --build-primary ${runTests} -b ${g.bootstrap.buildDir} -d ${out}.d -o ${out} ${in}
-    depfile = ${out}.d
-    description = minibp ${out}
-
-rule s.bootstrap.minibp
-    command = ${g.bootstrap.BinDir}/minibp ${runTests} -b ${g.bootstrap.buildDir} -d ${out}.d -o ${out} ${in}
-    depfile = ${out}.d
-    description = minibp ${out}
-    restat = true
-
-build ${g.bootstrap.buildDir}/.bootstrap/build.ninja: s.bootstrap.primarybp $
-        ${g.bootstrap.srcDir}/Blueprints | ${g.bootstrap.BinDir}/gotestmain $
-        ${g.bootstrap.BinDir}/gotestrunner ${g.bootstrap.BinDir}/minibp $
-        ${g.bootstrap.srcDir}/Blueprints
+build ${g.bootstrap.buildDir}/.bootstrap/build.ninja: g.bootstrap.build.ninja $
+        ${g.bootstrap.srcDir}/Blueprints | ${builder} $
+        ${g.bootstrap.BinDir}/gotestmain ${g.bootstrap.BinDir}/gotestrunner $
+        ${g.bootstrap.BinDir}/minibp ${g.bootstrap.srcDir}/Blueprints
+    builder = ${g.bootstrap.BinDir}/minibp
+    extra = --build-primary
 default ${g.bootstrap.buildDir}/.bootstrap/build.ninja
 
 build ${g.bootstrap.buildDir}/.minibootstrap/build.ninja.in: $
-        s.bootstrap.minibp ${g.bootstrap.srcDir}/Blueprints | $
-        ${g.bootstrap.BinDir}/minibp
+        g.bootstrap.build.ninja ${g.bootstrap.srcDir}/Blueprints | ${builder}
+    builder = ${g.bootstrap.BinDir}/minibp
+    extra = 
 default ${g.bootstrap.buildDir}/.minibootstrap/build.ninja.in
 
 build ${g.bootstrap.buildDir}/.minibootstrap/build.ninja: $

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,7 +17,7 @@ if [[ -d .bootstrap/blueprint/test ]]; then
 fi
 
 sleep 2
-sed -i 's/${runTests}/-t/' src.build.ninja.in
+sed -i 's/extra =/extra = -t/' src.build.ninja.in
 ./blueprint.bash
 
 if [[ ! -d .bootstrap/blueprint/test ]]; then


### PR DESCRIPTION
Soong (and soon, Blueprint, with #131 ) embeds the results of filesystem globs into the build.ninja, and uses a helper tool to detect when the glob changes and we need to rebuild the build.ninja file. This is more flexible than listing the affected directories in the depfiles, since it can check to
see if a file we actually cared about was added, instead of re-running anytime any file was added/removed (which happens on atomic file modifications as well).

My recent bootstrap simplification broke this, since the helper rules are in the main build.ninja, but I removed the ability to regenerate that file from itself. So keep the current model, but add a rule into the primary and main stages that allow themselves to re-run their generator and write out a new build.ninja file if necessary. The actual build rules of the generator aren't necessary, since we already built them in the previous stage.

Also includes some cleanup commits that parallelizes doc and test generation to improve bootstrapping times.