### PR TITLE
Add better error message when stat returns nil

### DIFF
--- a/pathtools/glob.go
+++ b/pathtools/glob.go
@@ -16,6 +16,7 @@ package pathtools
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -113,7 +114,11 @@ func glob(pattern string, hasRecursive bool) (matches, dirs []string, err error)
 	}
 
 	for _, m := range dirMatches {
-		if info, _ := os.Stat(m); info.IsDir() {
+		info, err := os.Stat(m)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unexpected error after glob: %s", err)
+		}
+		if info.IsDir() {
 			if file == "**" {
 				recurseDirs, err := walkAllDirs(m)
 				if err != nil {


### PR DESCRIPTION
Sometimes os.Stat on a path seems to return nil after filepath.Glob
returned the path as valid.  Return the error message to see why.

Bug: 32676828
Test: builds
Change-Id: Ieedddb673b4d641e5de08778febeb3d8ea025c0d