### PR TITLE
Fix optional_subdirs globbing

### DIFF
--- a/context.go
+++ b/context.go
@@ -31,7 +31,6 @@ import (
 	"text/template"
 
 	"github.com/google/blueprint/parser"
-	"github.com/google/blueprint/pathtools"
 	"github.com/google/blueprint/proptools"
 )
 
@@ -822,12 +821,7 @@ func (c *Context) findBuildBlueprints(dir string, build []string,
 		var matches []string
 		var err error
 
-		if pathtools.IsGlob(pattern) {
-			matches, err = c.glob(pattern, nil)
-		} else {
-			// Not a glob, but use filepath.Glob to check if it exists
-			matches, err = filepath.Glob(pattern)
-		}
+		matches, err = c.glob(pattern, nil)
 
 		if err != nil {
 			errs = append(errs, &BlueprintError{
@@ -863,12 +857,7 @@ func (c *Context) findSubdirBlueprints(dir string, subdirs []string, subdirsPos 
 		var matches []string
 		var err error
 
-		if pathtools.IsGlob(pattern) {
-			matches, err = c.glob(pattern, nil)
-		} else {
-			// Not a glob, but use filepath.Glob to check if it exists
-			matches, err = filepath.Glob(pattern)
-		}
+		matches, err = c.glob(pattern, nil)
 
 		if err != nil {
 			errs = append(errs, &BlueprintError{

--- a/pathtools/glob.go
+++ b/pathtools/glob.go
@@ -47,7 +47,7 @@ func Glob(pattern string) (matches, dirs []string, err error) {
 // that were searched to construct the file list.  The supported glob and
 // exclude patterns are equivalent to filepath.Glob, with an extension that
 // recursive glob (** matching zero or more complete path entries) is supported.
-// GlobWIthExcludes also returns a list of directories that were searched.
+// GlobWithExcludes also returns a list of directories that were searched.
 //
 // In general ModuleContext.GlobWithDeps or SingletonContext.GlobWithDeps
 // should be used instead, as they will automatically set up dependencies


### PR DESCRIPTION
Bypassing c.glob() and using filepath.Glob() directly for non-glob
paths does not add dependencies on directories that contain missing
files.  For optional_subdirs, this means no dependency is added to
rerun the primary builder when an Android.bp file is added to an
optional_subdirs directory.  Always use c.glob(), for the non-optional
case it will not insert any dependencies if the file exists (as tested
by glob_test.go's no-wild tests), and if the file doesn't exist the
len(matches) == 0 will error out.

Change-Id: I370479c6e89f5ff590897702e256256a4dca6952