### PR TITLE
Improve testing tools

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -612,6 +612,7 @@ func (s *singleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 
 	case 1:
 		primaryBuilderName = ctx.ModuleName(primaryBuilders[0])
+		primaryBuilderExtraFlags = extraTestFlags
 
 	default:
 		ctx.Errorf("multiple primary builder modules present:")

--- a/gotestmain/gotestmain.go
+++ b/gotestmain/gotestmain.go
@@ -85,6 +85,7 @@ var testMainTmpl = template.Must(template.New("testMain").Parse(`
 package main
 
 import (
+	"regexp"
 	"testing"
 
 	pkg "{{.Package}}"
@@ -96,8 +97,18 @@ var t = []testing.InternalTest{
 {{end}}
 }
 
-func matchString(pat, str string) (bool, error) {
-	return true, nil
+var matchPat string
+var matchRe *regexp.Regexp
+
+func matchString(pat, str string) (result bool, err error) {
+	if matchRe == nil || matchPat != pat {
+		matchPat = pat
+		matchRe, err = regexp.Compile(matchPat)
+		if err != nil {
+			return
+		}
+	}
+	return matchRe.MatchString(str), nil
 }
 
 func main() {


### PR DESCRIPTION
A few changes that were needed when I was writing tests for some Soong tools:

* Actually running tests for tools built during the main stage
* Making -test.run work for the test binaries (used to test os.Exit scenarios by re-executing the current binary)
* Fixing GOROOT during test runs