### PR TITLE
Sort testcases to make build (more) reproducible

### DIFF
--- a/gotestmain/gotestmain.go
+++ b/gotestmain/gotestmain.go
@@ -23,6 +23,7 @@ import (
 	"go/token"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -51,6 +52,7 @@ func findTests(srcs []string) (tests []string) {
 			tests = append(tests, obj.Name)
 		}
 	}
+	sort.Strings(tests)
 	return
 }
 


### PR DESCRIPTION
f.Scope.Objects is a map, so iteration order isn't defined. To fix this, lets just sort the testcase list so that it's always consistent.

There are still some paths in the built go files, but this improves repeatability using the same paths.

Test: Build twice, compare generated test.go files.