### PR TITLE
Added a check in Blueprint level for BaseDependencyTag

### DIFF
--- a/context.go
+++ b/context.go
@@ -1191,6 +1191,10 @@ func (c *Context) findMatchingVariant(module *moduleInfo, possible []*moduleInfo
 }
 
 func (c *Context) addDependency(module *moduleInfo, tag DependencyTag, depName string) []error {
+	if _, ok := tag.(BaseDependencyTag); ok {
+		panic("BaseDependencyTag is not allowed to be used directly!")
+	}
+
 	if depName == module.Name() {
 		return []error{&BlueprintError{
 			Err: fmt.Errorf("%q depends on itself", depName),
@@ -1262,6 +1266,9 @@ func (c *Context) findReverseDependency(module *moduleInfo, destName string) (*m
 
 func (c *Context) addVariationDependency(module *moduleInfo, variations []Variation,
 	tag DependencyTag, depName string, far bool) []error {
+	if _, ok := tag.(BaseDependencyTag); ok {
+		panic("BaseDependencyTag is not allowed to be used directly!")
+	}
 
 	possibleDeps := c.modulesFromName(depName)
 	if possibleDeps == nil {
@@ -1328,6 +1335,9 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 
 func (c *Context) addInterVariantDependency(origModule *moduleInfo, tag DependencyTag,
 	from, to Module) {
+	if _, ok := tag.(BaseDependencyTag); ok {
+		panic("BaseDependencyTag is not allowed to be used directly!")
+	}
 
 	var fromInfo, toInfo *moduleInfo
 	for _, m := range origModule.splitModules {

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -660,6 +660,10 @@ func (mctx *mutatorContext) AddDependency(module Module, tag DependencyTag, deps
 // collected until the end of the mutator pass, sorted by name, and then appended to the destination
 // module's dependency list.
 func (mctx *mutatorContext) AddReverseDependency(module Module, tag DependencyTag, destName string) {
+	if _, ok := tag.(BaseDependencyTag); ok {
+		panic("BaseDependencyTag is not allowed to be used directly!")
+	}
+
 	destModule, errs := mctx.context.findReverseDependency(mctx.context.moduleInfo[module], destName)
 	if len(errs) > 0 {
 		mctx.errs = append(mctx.errs, errs...)


### PR DESCRIPTION
It is not allowed to directly use BaseDependencyTag as customized user dependency tag passed down to Blueprint since it might cause issues that different type of modules will be mixed when fetched based on Tag.