### PR TITLE
Allow BuildParams to override ninja description

### DIFF
--- a/live_tracker.go
+++ b/live_tracker.go
@@ -68,6 +68,13 @@ func (l *liveTracker) AddBuildDefDeps(def *buildDef) error {
 		return err
 	}
 
+	for _, value := range def.Variables {
+		err = l.addNinjaStringDeps(value)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, value := range def.Args {
 		err = l.addNinjaStringDeps(value)
 		if err != nil {

--- a/ninja_strings_test.go
+++ b/ninja_strings_test.go
@@ -71,6 +71,11 @@ var ninjaParseTestCases = []struct {
 		strs:  []string{"foo bar"},
 	},
 	{
+		input: " foo ",
+		vars:  nil,
+		strs:  []string{"$ foo "},
+	},
+	{
 		input: "foo $ bar",
 		err:   "invalid character after '$' at byte offset 5",
 	},


### PR DESCRIPTION
Allow the ninja description variable to be set on build statements
as well as rules.

Escape leading space in ninja strings 