### PR TITLE
Fix glob deps for non-wild patterns

### DIFF
--- a/pathtools/glob_test.go
+++ b/pathtools/glob_test.go
@@ -27,68 +27,68 @@ var globTestCases = []struct {
 	pattern  string
 	matches  []string
 	excludes []string
-	dirs     []string
+	deps     []string
 	err      error
 }{
 	// Current directory tests
 	{
 		pattern: "*",
 		matches: []string{"a", "b", "c", "d.ext", "e.ext"},
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 	{
 		pattern: "*.ext",
 		matches: []string{"d.ext", "e.ext"},
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 	{
 		pattern: "*/a",
 		matches: []string{"a/a", "b/a"},
-		dirs:    []string{".", "a", "b", "c"},
+		deps:    []string{".", "a", "b", "c"},
 	},
 	{
 		pattern: "*/*/a",
 		matches: []string{"a/a/a"},
-		dirs:    []string{".", "a", "b", "c", "a/a", "a/b", "c/f", "c/g", "c/h"},
+		deps:    []string{".", "a", "b", "c", "a/a", "a/b", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern: "*/a/a",
 		matches: []string{"a/a/a"},
-		dirs:    []string{".", "a", "b", "c", "a/a"},
+		deps:    []string{".", "a", "b", "c", "a/a"},
 	},
 
 	// ./ directory tests
 	{
 		pattern: "./*",
 		matches: []string{"a", "b", "c", "d.ext", "e.ext"},
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 	{
 		pattern: "./*.ext",
 		matches: []string{"d.ext", "e.ext"},
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 	{
 		pattern: "./*/a",
 		matches: []string{"a/a", "b/a"},
-		dirs:    []string{".", "a", "b", "c"},
+		deps:    []string{".", "a", "b", "c"},
 	},
 	{
 		pattern: "./[ac]/a",
 		matches: []string{"a/a"},
-		dirs:    []string{".", "a", "c"},
+		deps:    []string{".", "a", "c"},
 	},
 
 	// subdirectory tests
 	{
 		pattern: "c/*/*.ext",
 		matches: []string{"c/f/f.ext", "c/g/g.ext"},
-		dirs:    []string{"c", "c/f", "c/g", "c/h"},
+		deps:    []string{"c", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern: "a/*/a",
 		matches: []string{"a/a/a"},
-		dirs:    []string{"a", "a/a", "a/b"},
+		deps:    []string{"a", "a/a", "a/b"},
 	},
 
 	// absolute tests
@@ -98,7 +98,7 @@ var globTestCases = []struct {
 			filepath.Join(pwd, "testdata/c/f/f.ext"),
 			filepath.Join(pwd, "testdata/c/g/g.ext"),
 		},
-		dirs: []string{
+		deps: []string{
 			filepath.Join(pwd, "testdata/c"),
 			filepath.Join(pwd, "testdata/c/f"),
 			filepath.Join(pwd, "testdata/c/g"),
@@ -110,41 +110,41 @@ var globTestCases = []struct {
 	{
 		pattern: "a",
 		matches: []string{"a"},
-		dirs:    nil,
+		deps:    []string{"a"},
 	},
 	{
 		pattern: "a/a",
 		matches: []string{"a/a"},
-		dirs:    nil,
+		deps:    []string{"a/a"},
 	},
 
 	// clean tests
 	{
 		pattern: "./c/*/*.ext",
 		matches: []string{"c/f/f.ext", "c/g/g.ext"},
-		dirs:    []string{"c", "c/f", "c/g", "c/h"},
+		deps:    []string{"c", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern: "c/../c/*/*.ext",
 		matches: []string{"c/f/f.ext", "c/g/g.ext"},
-		dirs:    []string{"c", "c/f", "c/g", "c/h"},
+		deps:    []string{"c", "c/f", "c/g", "c/h"},
 	},
 
 	// recursive tests
 	{
 		pattern: "**/a",
 		matches: []string{"a", "a/a", "a/a/a", "b/a"},
-		dirs:    []string{".", "a", "a/a", "a/b", "b", "c", "c/f", "c/g", "c/h"},
+		deps:    []string{".", "a", "a/a", "a/b", "b", "c", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern: "a/**/a",
 		matches: []string{"a/a", "a/a/a"},
-		dirs:    []string{"a", "a/a", "a/b"},
+		deps:    []string{"a", "a/a", "a/b"},
 	},
 	{
 		pattern: "a/**/*",
 		matches: []string{"a/a", "a/b", "a/a/a", "a/b/b"},
-		dirs:    []string{"a", "a/a", "a/b"},
+		deps:    []string{"a", "a/a", "a/b"},
 	},
 
 	// absolute recursive tests
@@ -156,7 +156,7 @@ var globTestCases = []struct {
 			filepath.Join(pwd, "testdata/c/f/f.ext"),
 			filepath.Join(pwd, "testdata/c/g/g.ext"),
 		},
-		dirs: []string{
+		deps: []string{
 			filepath.Join(pwd, "testdata"),
 			filepath.Join(pwd, "testdata/a"),
 			filepath.Join(pwd, "testdata/a/a"),
@@ -200,31 +200,31 @@ var globTestCases = []struct {
 		pattern:  "*.ext",
 		excludes: []string{"d.ext"},
 		matches:  []string{"e.ext"},
-		dirs:     []string{"."},
+		deps:     []string{"."},
 	},
 	{
 		pattern:  "*/*",
 		excludes: []string{"a/b"},
 		matches:  []string{"a/a", "b/a", "c/c", "c/f", "c/g", "c/h"},
-		dirs:     []string{".", "a", "b", "c"},
+		deps:     []string{".", "a", "b", "c"},
 	},
 	{
 		pattern:  "*/*",
 		excludes: []string{"a/b", "c/c"},
 		matches:  []string{"a/a", "b/a", "c/f", "c/g", "c/h"},
-		dirs:     []string{".", "a", "b", "c"},
+		deps:     []string{".", "a", "b", "c"},
 	},
 	{
 		pattern:  "*/*",
 		excludes: []string{"c/*", "*/a"},
 		matches:  []string{"a/b"},
-		dirs:     []string{".", "a", "b", "c"},
+		deps:     []string{".", "a", "b", "c"},
 	},
 	{
 		pattern:  "*/*",
 		excludes: []string{"*/*"},
 		matches:  nil,
-		dirs:     []string{".", "a", "b", "c"},
+		deps:     []string{".", "a", "b", "c"},
 	},
 
 	// absolute exclude tests
@@ -234,7 +234,7 @@ var globTestCases = []struct {
 		matches: []string{
 			filepath.Join(pwd, "testdata/c/g/g.ext"),
 		},
-		dirs: []string{
+		deps: []string{
 			filepath.Join(pwd, "testdata/c"),
 			filepath.Join(pwd, "testdata/c/f"),
 			filepath.Join(pwd, "testdata/c/g"),
@@ -247,7 +247,7 @@ var globTestCases = []struct {
 		matches: []string{
 			filepath.Join(pwd, "testdata/c/g/g.ext"),
 		},
-		dirs: []string{
+		deps: []string{
 			filepath.Join(pwd, "testdata/c"),
 			filepath.Join(pwd, "testdata/c/f"),
 			filepath.Join(pwd, "testdata/c/g"),
@@ -260,43 +260,43 @@ var globTestCases = []struct {
 		pattern:  "*.ext",
 		excludes: []string{"**/*.ext"},
 		matches:  nil,
-		dirs:     []string{"."},
+		deps:     []string{"."},
 	},
 	{
 		pattern:  "*/*",
 		excludes: []string{"**/b"},
 		matches:  []string{"a/a", "b/a", "c/c", "c/f", "c/g", "c/h"},
-		dirs:     []string{".", "a", "b", "c"},
+		deps:     []string{".", "a", "b", "c"},
 	},
 	{
 		pattern:  "*/*",
 		excludes: []string{"a/**/*"},
 		matches:  []string{"b/a", "c/c", "c/f", "c/g", "c/h"},
-		dirs:     []string{".", "a", "b", "c"},
+		deps:     []string{".", "a", "b", "c"},
 	},
 	{
 		pattern:  "**/*",
 		excludes: []string{"**/*"},
 		matches:  nil,
-		dirs:     []string{".", "a", "a/a", "a/b", "b", "c", "c/f", "c/g", "c/h"},
+		deps:     []string{".", "a", "a/a", "a/b", "b", "c", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern:  "*/*/*",
 		excludes: []string{"a/**/a"},
 		matches:  []string{"a/b/b", "c/f/f.ext", "c/g/g.ext", "c/h/h"},
-		dirs:     []string{".", "a", "b", "c", "a/a", "a/b", "c/f", "c/g", "c/h"},
+		deps:     []string{".", "a", "b", "c", "a/a", "a/b", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern:  "*/*/*",
 		excludes: []string{"**/a"},
 		matches:  []string{"a/b/b", "c/f/f.ext", "c/g/g.ext", "c/h/h"},
-		dirs:     []string{".", "a", "b", "c", "a/a", "a/b", "c/f", "c/g", "c/h"},
+		deps:     []string{".", "a", "b", "c", "a/a", "a/b", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern:  "c/*/*.ext",
 		excludes: []string{"c/**/f.ext"},
 		matches:  []string{"c/g/g.ext"},
-		dirs:     []string{"c", "c/f", "c/g", "c/h"},
+		deps:     []string{"c", "c/f", "c/g", "c/h"},
 	},
 
 	// absoulte recursive exclude tests
@@ -306,7 +306,7 @@ var globTestCases = []struct {
 		matches: []string{
 			filepath.Join(pwd, "testdata/c/g/g.ext"),
 		},
-		dirs: []string{
+		deps: []string{
 			filepath.Join(pwd, "testdata/c"),
 			filepath.Join(pwd, "testdata/c/f"),
 			filepath.Join(pwd, "testdata/c/g"),
@@ -319,71 +319,71 @@ var globTestCases = []struct {
 		pattern:  "./c/*/*.ext",
 		excludes: []string{"./c/*/f.ext"},
 		matches:  []string{"c/g/g.ext"},
-		dirs:     []string{"c", "c/f", "c/g", "c/h"},
+		deps:     []string{"c", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern:  "c/*/*.ext",
 		excludes: []string{"./c/*/f.ext"},
 		matches:  []string{"c/g/g.ext"},
-		dirs:     []string{"c", "c/f", "c/g", "c/h"},
+		deps:     []string{"c", "c/f", "c/g", "c/h"},
 	},
 	{
 		pattern:  "./c/*/*.ext",
 		excludes: []string{"c/*/f.ext"},
 		matches:  []string{"c/g/g.ext"},
-		dirs:     []string{"c", "c/f", "c/g", "c/h"},
+		deps:     []string{"c", "c/f", "c/g", "c/h"},
 	},
 
 	// non-existant non-wild path tests
 	{
 		pattern: "d/*",
 		matches: nil,
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 	{
 		pattern: "d",
 		matches: nil,
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 	{
 		pattern: "a/d/*",
 		matches: nil,
-		dirs:    []string{"a"},
+		deps:    []string{"a"},
 	},
 	{
 		pattern: "a/d",
 		matches: nil,
-		dirs:    []string{"a"},
+		deps:    []string{"a"},
 	},
 	{
 		pattern: "a/a/d/*",
 		matches: nil,
-		dirs:    []string{"a/a"},
+		deps:    []string{"a/a"},
 	},
 	{
 		pattern: "a/a/d",
 		matches: nil,
-		dirs:    []string{"a/a"},
+		deps:    []string{"a/a"},
 	},
 	{
 		pattern: "a/d/a/*",
 		matches: nil,
-		dirs:    []string{"a"},
+		deps:    []string{"a"},
 	},
 	{
 		pattern: "a/d/a",
 		matches: nil,
-		dirs:    []string{"a"},
+		deps:    []string{"a"},
 	},
 	{
 		pattern: "a/d/a/*/a",
 		matches: nil,
-		dirs:    []string{"a"},
+		deps:    []string{"a"},
 	},
 	{
 		pattern: "a/d/a/**/a",
 		matches: nil,
-		dirs:    []string{"a"},
+		deps:    []string{"a"},
 	},
 
 	// recursive exclude error tests
@@ -422,22 +422,22 @@ var globTestCases = []struct {
 	{
 		pattern: ".test/*",
 		matches: []string{".test/a"},
-		dirs:    []string{".test"},
+		deps:    []string{".test"},
 	},
 	{
 		pattern: ".t*/a",
 		matches: []string{".test/a"},
-		dirs:    []string{".", ".test"},
+		deps:    []string{".", ".test"},
 	},
 	{
 		pattern: ".*/.*",
 		matches: []string{".test/.ing"},
-		dirs:    []string{".", ".test"},
+		deps:    []string{".", ".test"},
 	},
 	{
 		pattern: ".t*",
 		matches: []string{".test", ".testing"},
-		dirs:    []string{"."},
+		deps:    []string{"."},
 	},
 }
 
@@ -445,7 +445,7 @@ func TestGlob(t *testing.T) {
 	os.Chdir("testdata")
 	defer os.Chdir("..")
 	for _, testCase := range globTestCases {
-		matches, dirs, err := Glob(testCase.pattern, testCase.excludes)
+		matches, deps, err := Glob(testCase.pattern, testCase.excludes)
 		if err != testCase.err {
 			t.Errorf(" pattern: %q", testCase.pattern)
 			if testCase.excludes != nil {
@@ -464,14 +464,14 @@ func TestGlob(t *testing.T) {
 			t.Errorf("     got: %#v", matches)
 			t.Errorf("expected: %#v", testCase.matches)
 		}
-		if !reflect.DeepEqual(dirs, testCase.dirs) {
-			t.Errorf("incorrect dirs list:")
+		if !reflect.DeepEqual(deps, testCase.deps) {
+			t.Errorf("incorrect deps list:")
 			t.Errorf(" pattern: %q", testCase.pattern)
 			if testCase.excludes != nil {
 				t.Errorf("excludes: %q", testCase.excludes)
 			}
-			t.Errorf("     got: %#v", dirs)
-			t.Errorf("expected: %#v", testCase.dirs)
+			t.Errorf("     got: %#v", deps)
+			t.Errorf("expected: %#v", testCase.deps)
 		}
 	}
 }


### PR DESCRIPTION
Patterns that were not wild would return an empty "dirs" list if the
file was found. But then if they were removed, we wouldn't know to
update the glob file and re-run the primary builder.

In this case, instead of adding the final directory into the dirs list,
add the matched files themselves. Due to editors performing atomic
writes (the directory timestamp often gets updated at the same time as
file timestamp) this is probably more efficient. In either case, we're
only re-running the individual glob, which is rather cheap.

Rename startGlob/Glob return name from "dirs" to "deps" since it may
contain files now too.