### PR TITLE
Go 1.9 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
     - 1.8.3
+    - 1.9rc1
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
     - source .travis.fix-fork.sh
 
 script:
+    - export GOROOT=$(go env GOROOT)
     - ./.travis.gofmt.sh
     - go test ./...
     - ./tests/test.sh

--- a/blueprint_impl.bash
+++ b/blueprint_impl.bash
@@ -3,6 +3,8 @@ if [ ! "${BLUEPRINT_BOOTSTRAP_VERSION}" -eq "1" ]; then
   exit 1
 fi
 
+export GOROOT
+
 source "${BLUEPRINTDIR}/microfactory/microfactory.bash"
 
 BUILDDIR="${BUILDDIR}/.minibootstrap" build_go minibp github.com/google/blueprint/bootstrap/minibp

--- a/gotestmain/gotestmain.go
+++ b/gotestmain/gotestmain.go
@@ -156,6 +156,10 @@ func (matchString) WriteProfileTo(string, io.Writer, int) error {
     panic("shouldn't get here")
 }
 
+func (matchString) ImportPath() string {
+	return "{{.Package}}"
+}
+
 func main() {
 {{if .MainStartTakesInterface}}
 	m := testing.MainStart(matchString{}, t, nil, nil)

--- a/microfactory/microfactory.go
+++ b/microfactory/microfactory.go
@@ -69,6 +69,7 @@ var (
 
 	goToolDir = filepath.Join(runtime.GOROOT(), "pkg", "tool", runtime.GOOS+"_"+runtime.GOARCH)
 	goVersion = findGoVersion()
+	isGo18    = strings.Contains(goVersion, "go1.8")
 )
 
 func findGoVersion() string {
@@ -276,6 +277,9 @@ func (p *GoPackage) Compile(outDir, trimPath string) error {
 		"-o", p.output,
 		"-p", p.Name,
 		"-complete", "-pack", "-nolocalimports")
+	if !isGo18 {
+		cmd.Args = append(cmd.Args, "-c", fmt.Sprintf("%d", runtime.NumCPU()))
+	}
 	if race {
 		cmd.Args = append(cmd.Args, "-race")
 		fmt.Fprintln(hash, "-race")


### PR DESCRIPTION
Tell travis to test go1.9beta2, fix the build break in gotestmain, and enable the new parallel compilation support in the go compiler.