### PR TITLE
Add TopDownMutatorContext.CreateModule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
     - export GOROOT=$(go env GOROOT)
     - ./.travis.gofmt.sh
     - go test ./...
+    - go test -race -short ./...
     - ./tests/test.sh
     - ./tests/test_tree_tests.sh
     - ./tests/test_tree_tests.sh -t

--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -128,10 +128,11 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	// Add extra ninja file dependencies
 	deps = append(deps, extraNinjaFileDeps...)
 
-	errs = ctx.ResolveDependencies(config)
+	extraDeps, errs := ctx.ResolveDependencies(config)
 	if len(errs) > 0 {
 		fatalErrors(errs)
 	}
+	deps = append(deps, extraDeps...)
 
 	if docFile != "" {
 		err := writeDocs(ctx, filepath.Dir(bootstrapConfig.topLevelBlueprintsFile), docFile)
@@ -141,7 +142,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		return
 	}
 
-	extraDeps, errs := ctx.PrepareBuildActions(config)
+	extraDeps, errs = ctx.PrepareBuildActions(config)
 	if len(errs) > 0 {
 		fatalErrors(errs)
 	}

--- a/context.go
+++ b/context.go
@@ -1755,7 +1755,7 @@ func (c *Context) runMutator(config interface{}, mutator *mutatorInfo,
 
 	errsCh := make(chan []error)
 	globalStateCh := make(chan globalStateChange)
-	newModulesCh := make(chan []*moduleInfo)
+	newVariationsCh := make(chan []*moduleInfo)
 	done := make(chan bool)
 
 	c.depsModified = 0
@@ -1794,8 +1794,8 @@ func (c *Context) runMutator(config interface{}, mutator *mutatorInfo,
 			return true
 		}
 
-		if len(mctx.newModules) > 0 {
-			newModulesCh <- mctx.newModules
+		if len(mctx.newVariations) > 0 {
+			newVariationsCh <- mctx.newVariations
 		}
 
 		if len(mctx.reverseDeps) > 0 || len(mctx.replace) > 0 || len(mctx.rename) > 0 {
@@ -1821,8 +1821,8 @@ func (c *Context) runMutator(config interface{}, mutator *mutatorInfo,
 				}
 				replace = append(replace, globalStateChange.replace...)
 				rename = append(rename, globalStateChange.rename...)
-			case newModules := <-newModulesCh:
-				for _, m := range newModules {
+			case newVariations := <-newVariationsCh:
+				for _, m := range newVariations {
 					newModuleInfo[m.logicModule] = m
 				}
 			case <-done:

--- a/context.go
+++ b/context.go
@@ -165,9 +165,9 @@ type moduleInfo struct {
 	variant           variationMap
 	dependencyVariant variationMap
 
-	logicModule      Module
-	group            *moduleGroup
-	moduleProperties []interface{}
+	logicModule Module
+	group       *moduleGroup
+	properties  []interface{}
 
 	// set during ResolveDependencies
 	directDeps  []depInfo
@@ -948,13 +948,13 @@ func (c *Context) cloneLogicModule(origModule *moduleInfo) (Module, []interface{
 
 	newLogicModule, newProperties := factory()
 
-	if len(newProperties) != len(origModule.moduleProperties) {
+	if len(newProperties) != len(origModule.properties) {
 		panic("mismatched properties array length in " + origModule.Name())
 	}
 
 	for i := range newProperties {
 		dst := reflect.ValueOf(newProperties[i]).Elem()
-		src := reflect.ValueOf(origModule.moduleProperties[i]).Elem()
+		src := reflect.ValueOf(origModule.properties[i]).Elem()
 
 		proptools.CopyProperties(dst, src)
 	}
@@ -982,7 +982,7 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 			// Reuse the existing module for the first new variant
 			// This both saves creating a new module, and causes the insertion in c.moduleInfo below
 			// with logicModule as the key to replace the original entry in c.moduleInfo
-			newLogicModule, newProperties = origModule.logicModule, origModule.moduleProperties
+			newLogicModule, newProperties = origModule.logicModule, origModule.properties
 		} else {
 			newLogicModule, newProperties = c.cloneLogicModule(origModule)
 		}
@@ -996,7 +996,7 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 		newModule.logicModule = newLogicModule
 		newModule.variant = newVariant
 		newModule.dependencyVariant = origModule.dependencyVariant.clone()
-		newModule.moduleProperties = newProperties
+		newModule.properties = newProperties
 
 		if variationName != "" {
 			if newModule.variantName == "" {
@@ -1087,7 +1087,7 @@ func (c *Context) processModuleDef(moduleDef *parser.Module,
 		relBlueprintsFile: relBlueprintsFile,
 	}
 
-	module.moduleProperties = properties
+	module.properties = properties
 
 	propertyMap, errs := unpackProperties(moduleDef.Properties, properties...)
 	if len(errs) > 0 {
@@ -1903,7 +1903,7 @@ func (c *Context) cloneModules() {
 	for _, m := range c.modulesSorted {
 		go func(m *moduleInfo) {
 			origLogicModule := m.logicModule
-			m.logicModule, m.moduleProperties = c.cloneLogicModule(m)
+			m.logicModule, m.properties = c.cloneLogicModule(m)
 			ch <- update{origLogicModule, m}
 		}(m)
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -105,7 +105,7 @@ func TestContextParse(t *testing.T) {
 		t.FailNow()
 	}
 
-	errs = ctx.ResolveDependencies(nil)
+	_, errs = ctx.ResolveDependencies(nil)
 	if len(errs) > 0 {
 		t.Errorf("unexpected dep errors:")
 		for _, err := range errs {
@@ -170,7 +170,7 @@ func TestWalkDeps(t *testing.T) {
 		t.FailNow()
 	}
 
-	errs = ctx.ResolveDependencies(nil)
+	_, errs = ctx.ResolveDependencies(nil)
 	if len(errs) > 0 {
 		t.Errorf("unexpected dep errors:")
 		for _, err := range errs {
@@ -228,7 +228,7 @@ func TestCreateModule(t *testing.T) {
 		t.FailNow()
 	}
 
-	errs = ctx.ResolveDependencies(nil)
+	_, errs = ctx.ResolveDependencies(nil)
 	if len(errs) > 0 {
 		t.Errorf("unexpected dep errors:")
 		for _, err := range errs {

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -498,11 +498,11 @@ func (m *moduleContext) GetMissingDependencies() []string {
 
 type mutatorContext struct {
 	baseModuleContext
-	name        string
-	reverseDeps []reverseDep
-	rename      []rename
-	replace     []replace
-	newModules  []*moduleInfo
+	name          string
+	reverseDeps   []reverseDep
+	rename        []rename
+	replace       []replace
+	newVariations []*moduleInfo
 }
 
 type baseMutatorContext interface {
@@ -620,10 +620,10 @@ func (mctx *mutatorContext) createVariations(variationNames []string, local bool
 		}
 	}
 
-	if mctx.newModules != nil {
+	if mctx.newVariations != nil {
 		panic("module already has variations from this mutator")
 	}
-	mctx.newModules = modules
+	mctx.newVariations = modules
 
 	if len(ret) != len(variationNames) {
 		panic("oops!")

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -498,6 +498,49 @@ var validUnpackTestCases = []struct {
 			},
 		},
 	},
+
+	// Factory set properties
+	{
+		input: `
+			m {
+				string: "abc",
+				string_ptr: "abc",
+				bool: false,
+				bool_ptr: false,
+				list: ["a", "b", "c"],
+			}
+		`,
+		output: []interface{}{
+			struct {
+				String     string
+				String_ptr *string
+				Bool       bool
+				Bool_ptr   *bool
+				List       []string
+			}{
+				String:     "012abc",
+				String_ptr: proptools.StringPtr("abc"),
+				Bool:       true,
+				Bool_ptr:   proptools.BoolPtr(false),
+				List:       []string{"0", "1", "2", "a", "b", "c"},
+			},
+		},
+		empty: []interface{}{
+			&struct {
+				String     string
+				String_ptr *string
+				Bool       bool
+				Bool_ptr   *bool
+				List       []string
+			}{
+				String:     "012",
+				String_ptr: proptools.StringPtr("012"),
+				Bool:       true,
+				Bool_ptr:   proptools.BoolPtr(true),
+				List:       []string{"0", "1", "2"},
+			},
+		},
+	},
 }
 
 type EmbeddedStruct struct{ Name string }

--- a/visit_test.go
+++ b/visit_test.go
@@ -126,7 +126,7 @@ func setupVisitTest(t *testing.T) *Context {
 		t.FailNow()
 	}
 
-	errs = ctx.ResolveDependencies(nil)
+	_, errs = ctx.ResolveDependencies(nil)
 	if len(errs) > 0 {
 		t.Errorf("unexpected dep errors:")
 		for _, err := range errs {


### PR DESCRIPTION
Allow a module to create other modules as if they were specified
in a blueprint file.  CreateModule takes the name of a module type,
calls the factory function the module type, and then inserts
properties into the property structs returned by the factory.