### PR TITLE
Clearer error in case of Android.bp being unreadable

### DIFF
--- a/pathtools/fs.go
+++ b/pathtools/fs.go
@@ -16,6 +16,7 @@ package pathtools
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -61,6 +62,7 @@ type FileSystem interface {
 	Glob(pattern string, excludes []string) (matches, dirs []string, err error)
 	glob(pattern string) (matches []string, err error)
 	IsDir(name string) (bool, error)
+	Lstat(name string) (os.FileInfo, error)
 }
 
 // osFs implements FileSystem using the local disk.
@@ -92,6 +94,10 @@ func (fs osFs) Glob(pattern string, excludes []string) (matches, dirs []string, 
 
 func (osFs) glob(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
+}
+
+func (osFs) Lstat(path string) (stats os.FileInfo, err error) {
+	return os.Lstat(path)
 }
 
 type mockFs struct {
@@ -149,4 +155,8 @@ func (m *mockFs) glob(pattern string) ([]string, error) {
 		}
 	}
 	return matches, nil
+}
+
+func (m *mockFs) Lstat(path string) (stats os.FileInfo, err error) {
+	return nil, errors.New("Lstat is not yet implemented in MockFs")
 }


### PR DESCRIPTION
Bug: 64600838
Test: mkdir errtest \
      && ln -s /tmp/dontexist errtest/Android.bp \
      # and add errtest to ./Android.bp \
      && m nothing \
      # and check that the error message mentions a symlink

Change-Id: I841ec12d613f61ccc3396538062bee48c8c1ca27