### PR TITLE
Allow rules to specify order-only dependencies

### DIFF
--- a/live_tracker.go
+++ b/live_tracker.go
@@ -109,6 +109,11 @@ func (l *liveTracker) addRule(r Rule) (def *ruleDef, err error) {
 			return nil, err
 		}
 
+		err = l.addNinjaStringListDeps(def.CommandOrderOnly)
+		if err != nil {
+			return nil, err
+		}
+
 		for _, value := range def.Variables {
 			err = l.addNinjaStringDeps(value)
 			if err != nil {


### PR DESCRIPTION
Commands that contain tools that don't affect the build results
may want an order-only dependency on the tool.  Allow rules
to specify order-only dependencies the same way they specify
implicit dependencies.

Test: builds
Change-Id: I3e0f886ae047b0fadf7a5c0dfeb9827d2c5c411d