### PR TITLE
Add file locking to microfactory

### DIFF
--- a/microfactory/microfactory.go
+++ b/microfactory/microfactory.go
@@ -485,6 +485,18 @@ func Build(config *Config, out, pkg string) (*GoPackage, error) {
 		Name: "main",
 	}
 
+	lockFileName := filepath.Join(filepath.Dir(out), "."+filepath.Base(out)+".lock")
+	lockFile, err := os.OpenFile(lockFileName, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating lock file (%q): %v", lockFileName, err)
+	}
+	defer lockFile.Close()
+
+	err = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		return nil, fmt.Errorf("Error locking file (%q): %v", lockFileName, err)
+	}
+
 	path, ok, err := config.Path(pkg)
 	if err != nil {
 		return nil, fmt.Errorf("Error finding package %q for main: %v", pkg, err)


### PR DESCRIPTION
To prevent against multiple instances attempting to rebuild the same executable, add a file lock to Build().

The trace file may not be consistent in this case, but everything that reads it should be able to handle a corrupted trace file.

Test: `while true; do <microfactory-enabled executable>; done` in parallel, and modify the code to microfactory (echo "//" >>microfactory.go)