### PR TITLE
Finish switching blueprint back to the original Blueprints format

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -1,12 +1,12 @@
-bootstrap_go_package(
-    name = "blueprint",
-    deps = [
+bootstrap_go_package {
+    name: "blueprint",
+    deps: [
         "blueprint-parser",
         "blueprint-pathtools",
         "blueprint-proptools",
     ],
-    pkgPath = "github.com/google/blueprint",
-    srcs = [
+    pkgPath: "github.com/google/blueprint",
+    srcs: [
         "context.go",
         "glob.go",
         "live_tracker.go",
@@ -20,82 +20,82 @@ bootstrap_go_package(
         "singleton_ctx.go",
         "unpack.go",
     ],
-    testSrcs = [
+    testSrcs: [
         "context_test.go",
         "ninja_strings_test.go",
         "ninja_writer_test.go",
         "splice_modules_test.go",
         "unpack_test.go",
-	"visit_test.go",
+        "visit_test.go",
     ],
-)
+}
 
-bootstrap_go_package(
-    name = "blueprint-parser",
-    pkgPath = "github.com/google/blueprint/parser",
-    srcs = [
+bootstrap_go_package {
+    name: "blueprint-parser",
+    pkgPath: "github.com/google/blueprint/parser",
+    srcs: [
         "parser/ast.go",
         "parser/modify.go",
         "parser/parser.go",
         "parser/printer.go",
         "parser/sort.go",
     ],
-    testSrcs = [
+    testSrcs: [
         "parser/parser_test.go",
         "parser/printer_test.go",
     ],
-)
+}
 
-bootstrap_go_package(
-    name = "blueprint-deptools",
-    pkgPath = "github.com/google/blueprint/deptools",
-    srcs = ["deptools/depfile.go"],
-)
+bootstrap_go_package {
+    name: "blueprint-deptools",
+    pkgPath: "github.com/google/blueprint/deptools",
+    srcs: ["deptools/depfile.go"],
+}
 
-bootstrap_go_package(
-    name = "blueprint-pathtools",
-    pkgPath = "github.com/google/blueprint/pathtools",
-    deps = [
+bootstrap_go_package {
+    name: "blueprint-pathtools",
+    pkgPath: "github.com/google/blueprint/pathtools",
+    deps: [
         "blueprint-deptools",
     ],
-    srcs = [
+    srcs: [
         "pathtools/lists.go",
         "pathtools/fs.go",
         "pathtools/glob.go",
     ],
-    testSrcs = [
+    testSrcs: [
         "pathtools/glob_test.go",
     ],
-)
+}
 
-bootstrap_go_package(
-    name = "blueprint-proptools",
-    pkgPath = "github.com/google/blueprint/proptools",
-    srcs = [
+bootstrap_go_package {
+    name: "blueprint-proptools",
+    pkgPath: "github.com/google/blueprint/proptools",
+    srcs: [
         "proptools/clone.go",
         "proptools/escape.go",
         "proptools/extend.go",
         "proptools/proptools.go",
         "proptools/typeequal.go",
     ],
-    testSrcs = [
+    testSrcs: [
         "proptools/clone_test.go",
         "proptools/escape_test.go",
         "proptools/extend_test.go",
         "proptools/typeequal_test.go",
     ],
-)
+}
 
-bootstrap_go_package(
-    name = "blueprint-bootstrap",
-    deps = [
+bootstrap_go_package {
+    name: "blueprint-bootstrap",
+    deps: [
         "blueprint",
         "blueprint-deptools",
         "blueprint-pathtools",
         "blueprint-bootstrap-bpdoc",
     ],
-    pkgPath = "github.com/google/blueprint/bootstrap",
-    srcs = [
+    pkgPath: "github.com/google/blueprint/bootstrap",
+    srcs: [
         "bootstrap/bootstrap.go",
         "bootstrap/cleanup.go",
         "bootstrap/command.go",
@@ -104,74 +104,74 @@ bootstrap_go_package(
         "bootstrap/glob.go",
         "bootstrap/writedocs.go",
     ],
-)
+}
 
-bootstrap_go_package(
-    name = "blueprint-bootstrap-bpdoc",
-    deps = [
+bootstrap_go_package {
+    name: "blueprint-bootstrap-bpdoc",
+    deps: [
         "blueprint",
         "blueprint-proptools",
     ],
-    pkgPath = "github.com/google/blueprint/bootstrap/bpdoc",
-    srcs = [
+    pkgPath: "github.com/google/blueprint/bootstrap/bpdoc",
+    srcs: [
         "bootstrap/bpdoc/bpdoc.go",
     ],
-)
+}
 
-bootstrap_go_binary(
-    name = "minibp",
-    deps = [
+bootstrap_go_binary {
+    name: "minibp",
+    deps: [
         "blueprint",
         "blueprint-bootstrap",
         "gotestmain-tests",
     ],
-    srcs = ["bootstrap/minibp/main.go"],
-)
+    srcs: ["bootstrap/minibp/main.go"],
+}
 
-bootstrap_go_binary(
-    name = "bpglob",
-    deps = ["blueprint-pathtools"],
-    srcs = ["bootstrap/bpglob/bpglob.go"],
-)
+bootstrap_go_binary {
+    name: "bpglob",
+    deps: ["blueprint-pathtools"],
+    srcs: ["bootstrap/bpglob/bpglob.go"],
+}
 
-blueprint_go_binary(
-    name = "bpfmt",
-    deps = ["blueprint-parser"],
-    srcs = ["bpfmt/bpfmt.go"],
-)
+blueprint_go_binary {
+    name: "bpfmt",
+    deps: ["blueprint-parser"],
+    srcs: ["bpfmt/bpfmt.go"],
+}
 
-blueprint_go_binary(
-    name = "bpmodify",
-    deps = ["blueprint-parser"],
-    srcs = ["bpmodify/bpmodify.go"],
-)
+blueprint_go_binary {
+    name: "bpmodify",
+    deps: ["blueprint-parser"],
+    srcs: ["bpmodify/bpmodify.go"],
+}
 
-bootstrap_go_binary(
-    name = "gotestmain",
-    srcs = ["gotestmain/gotestmain.go"],
-)
+bootstrap_go_binary {
+    name: "gotestmain",
+    srcs: ["gotestmain/gotestmain.go"],
+}
 
 // gotestmain tests can't be on the gotestmain module because it is an implicit dependency of tests.
 // Put the tests in their own package and make it a dependency of minibp to make sure they run.
-bootstrap_go_package(
-    name = "gotestmain-tests",
-    pkgPath = "github.com/google/blueprint/gotestmain",
-    srcs = [
+bootstrap_go_package {
+    name: "gotestmain-tests",
+    pkgPath: "github.com/google/blueprint/gotestmain",
+    srcs: [
         "gotestmain/dummy.go",
     ],
-    testSrcs = [
+    testSrcs: [
         "gotestmain/testmain_test.go",
     ],
-)
+}
 
-bootstrap_go_binary(
-    name = "gotestrunner",
-    srcs = ["gotestrunner/gotestrunner.go"],
-)
+bootstrap_go_binary {
+    name: "gotestrunner",
+    srcs: ["gotestrunner/gotestrunner.go"],
+}
 
-bootstrap_go_binary{
-    name = "loadplugins",
-    srcs = ["loadplugins/loadplugins.go"],
+bootstrap_go_binary {
+    name: "loadplugins",
+    srcs: ["loadplugins/loadplugins.go"],
 }
 
 blueprint_go_binary {

--- a/doc.go
+++ b/doc.go
@@ -35,15 +35,15 @@
 // the module type looks like a function call, and the properties of the module
 // look like optional arguments.  For example, a simple module might look like:
 //
-//   cc_library(
-//       name = "cmd",
-//       srcs = [
+//   cc_library {
+//       name: "cmd",
+//       srcs: [
 //           "main.c",
 //       ],
-//       deps = [
+//       deps: [
 //           "libc",
 //       ],
-//   )
+//   }
 //
 //   subdirs = ["subdir1", "subdir2"]
 //

--- a/tests/test_tree/Blueprints
+++ b/tests/test_tree/Blueprints
@@ -1,3 +1,3 @@
 // Root Blueprints file for test_tree
 
-subdirs=["*"]
+subdirs = ["*"]


### PR DESCRIPTION
An ill-fated experiment with using a format that was closer to
Bazel left Blueprint preferring the original style, but documenting
and using the new style.  Update the documentation and run bpfmt -w.

Test: builds
Change-Id: I3fb70c8fa50c332da01cf5912b179c60d1638814