### PR TITLE
Set fields in CreateModule to match current module

### DIFF
--- a/module_ctx.go
+++ b/module_ctx.go
@@ -745,6 +745,9 @@ func (mctx *mutatorContext) Rename(name string) {
 func (mctx *mutatorContext) CreateModule(factory ModuleFactory, props ...interface{}) {
 	module := mctx.context.newModule(factory)
 
+	module.relBlueprintsFile = mctx.module.relBlueprintsFile
+	module.pos = mctx.module.pos
+
 	for _, p := range props {
 		err := proptools.AppendMatchingProperties(module.properties, p, nil)
 		if err != nil {


### PR DESCRIPTION
When a mutator calls CreateModule, set the blueprints file and line
number to the values of the module that the mutator was visiting.

Change-Id: I4526f14a744be944e42582bc46f11a9a7b502f03