### PR TITLE
Support parsing int64 number in Blueprint file

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -161,6 +161,7 @@ type Type int
 const (
 	BoolType Type = iota + 1
 	StringType
+	Int64Type
 	ListType
 	MapType
 )
@@ -171,6 +172,8 @@ func (t Type) String() string {
 		return "bool"
 	case StringType:
 		return "string"
+	case Int64Type:
+		return "int64"
 	case ListType:
 		return "list"
 	case MapType:
@@ -348,6 +351,31 @@ func (x *String) String() string {
 
 func (x *String) Type() Type {
 	return StringType
+}
+
+type Int64 struct {
+	LiteralPos scanner.Position
+	Value      int64
+}
+
+func (x *Int64) Pos() scanner.Position { return x.LiteralPos }
+func (x *Int64) End() scanner.Position { return x.LiteralPos }
+
+func (x *Int64) Copy() Expression {
+	ret := *x
+	return &ret
+}
+
+func (x *Int64) Eval() Expression {
+	return x
+}
+
+func (x *Int64) String() string {
+	return fmt.Sprintf("%q@%s", x.Value, x.LiteralPos)
+}
+
+func (x *Int64) Type() Type {
+	return Int64Type
 }
 
 type Bool struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -110,6 +110,35 @@ var validParseTestCases = []struct {
 
 	{`
 		foo {
+			num: 4,
+		}
+		`,
+		[]Definition{
+			&Module{
+				Type:    "foo",
+				TypePos: mkpos(3, 2, 3),
+				Map: Map{
+					LBracePos: mkpos(7, 2, 7),
+					RBracePos: mkpos(22, 4, 3),
+					Properties: []*Property{
+						{
+							Name:     "num",
+							NamePos:  mkpos(12, 3, 4),
+							ColonPos: mkpos(15, 3, 7),
+							Value: &Int64{
+								LiteralPos: mkpos(17, 3, 9),
+								Value:      4,
+							},
+						},
+					},
+				},
+			},
+		},
+		nil,
+	},
+
+	{`
+		foo {
 			stuff: ["asdf", "jkl;", "qwert",
 				"uiop", "bnm,"]
 		}
@@ -164,7 +193,8 @@ var validParseTestCases = []struct {
 		foo {
 			stuff: {
 				isGood: true,
-				name: "bar"
+				name: "bar",
+				num: 36,
 			}
 		}
 		`,
@@ -174,7 +204,7 @@ var validParseTestCases = []struct {
 				TypePos: mkpos(3, 2, 3),
 				Map: Map{
 					LBracePos: mkpos(7, 2, 7),
-					RBracePos: mkpos(62, 7, 3),
+					RBracePos: mkpos(76, 8, 3),
 					Properties: []*Property{
 						{
 							Name:     "stuff",
@@ -182,7 +212,7 @@ var validParseTestCases = []struct {
 							ColonPos: mkpos(17, 3, 9),
 							Value: &Map{
 								LBracePos: mkpos(19, 3, 11),
-								RBracePos: mkpos(58, 6, 4),
+								RBracePos: mkpos(72, 7, 4),
 								Properties: []*Property{
 									{
 										Name:     "isGood",
@@ -200,6 +230,15 @@ var validParseTestCases = []struct {
 										Value: &String{
 											LiteralPos: mkpos(49, 5, 11),
 											Value:      "bar",
+										},
+									},
+									{
+										Name:     "num",
+										NamePos:  mkpos(60, 6, 5),
+										ColonPos: mkpos(63, 6, 8),
+										Value: &Int64{
+											LiteralPos: mkpos(65, 6, 10),
+											Value:      36,
 										},
 									},
 								},
@@ -279,10 +318,12 @@ var validParseTestCases = []struct {
 	{`
 		foo {
 			name: "abc",
+			num: 4,
 		}
 
 		bar {
 			name: "def",
+			num: -5,
 		}
 		`,
 		[]Definition{
@@ -291,7 +332,7 @@ var validParseTestCases = []struct {
 				TypePos: mkpos(3, 2, 3),
 				Map: Map{
 					LBracePos: mkpos(7, 2, 7),
-					RBracePos: mkpos(27, 4, 3),
+					RBracePos: mkpos(38, 5, 3),
 					Properties: []*Property{
 						{
 							Name:     "name",
@@ -302,23 +343,41 @@ var validParseTestCases = []struct {
 								Value:      "abc",
 							},
 						},
+						{
+							Name:     "num",
+							NamePos:  mkpos(28, 4, 4),
+							ColonPos: mkpos(31, 4, 7),
+							Value: &Int64{
+								LiteralPos: mkpos(33, 4, 9),
+								Value:      4,
+							},
+						},
 					},
 				},
 			},
 			&Module{
 				Type:    "bar",
-				TypePos: mkpos(32, 6, 3),
+				TypePos: mkpos(43, 7, 3),
 				Map: Map{
-					LBracePos: mkpos(36, 6, 7),
-					RBracePos: mkpos(56, 8, 3),
+					LBracePos: mkpos(47, 7, 7),
+					RBracePos: mkpos(79, 10, 3),
 					Properties: []*Property{
 						{
 							Name:     "name",
-							NamePos:  mkpos(41, 7, 4),
-							ColonPos: mkpos(45, 7, 8),
+							NamePos:  mkpos(52, 8, 4),
+							ColonPos: mkpos(56, 8, 8),
 							Value: &String{
-								LiteralPos: mkpos(47, 7, 10),
+								LiteralPos: mkpos(58, 8, 10),
 								Value:      "def",
+							},
+						},
+						{
+							Name:     "num",
+							NamePos:  mkpos(68, 9, 4),
+							ColonPos: mkpos(71, 9, 7),
+							Value: &Int64{
+								LiteralPos: mkpos(73, 9, 9),
+								Value:      -5,
 							},
 						},
 					},
@@ -327,6 +386,7 @@ var validParseTestCases = []struct {
 		},
 		nil,
 	},
+
 	{`
 		foo = "stuff"
 		bar = foo
@@ -557,6 +617,317 @@ var validParseTestCases = []struct {
 		},
 		nil,
 	},
+
+	{`
+		baz = -4 + -5 + 6
+		`,
+		[]Definition{
+			&Assignment{
+				Name:      "baz",
+				NamePos:   mkpos(3, 2, 3),
+				EqualsPos: mkpos(7, 2, 7),
+				Value: &Operator{
+					OperatorPos: mkpos(12, 2, 12),
+					Operator:    '+',
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      -3,
+					},
+					Args: [2]Expression{
+						&Int64{
+							LiteralPos: mkpos(9, 2, 9),
+							Value:      -4,
+						},
+						&Operator{
+							OperatorPos: mkpos(17, 2, 17),
+							Operator:    '+',
+							Value: &Int64{
+								LiteralPos: mkpos(14, 2, 14),
+								Value:      1,
+							},
+							Args: [2]Expression{
+								&Int64{
+									LiteralPos: mkpos(14, 2, 14),
+									Value:      -5,
+								},
+								&Int64{
+									LiteralPos: mkpos(19, 2, 19),
+									Value:      6,
+								},
+							},
+						},
+					},
+				},
+				OrigValue: &Operator{
+					OperatorPos: mkpos(12, 2, 12),
+					Operator:    '+',
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      -3,
+					},
+					Args: [2]Expression{
+						&Int64{
+							LiteralPos: mkpos(9, 2, 9),
+							Value:      -4,
+						},
+						&Operator{
+							OperatorPos: mkpos(17, 2, 17),
+							Operator:    '+',
+							Value: &Int64{
+								LiteralPos: mkpos(14, 2, 14),
+								Value:      1,
+							},
+							Args: [2]Expression{
+								&Int64{
+									LiteralPos: mkpos(14, 2, 14),
+									Value:      -5,
+								},
+								&Int64{
+									LiteralPos: mkpos(19, 2, 19),
+									Value:      6,
+								},
+							},
+						},
+					},
+				},
+				Assigner:   "=",
+				Referenced: false,
+			},
+		},
+		nil,
+	},
+
+	{`
+		foo = 1000000
+		bar = foo
+		baz = foo + bar
+		boo = baz
+		boo += foo
+		`,
+		[]Definition{
+			&Assignment{
+				Name:      "foo",
+				NamePos:   mkpos(3, 2, 3),
+				EqualsPos: mkpos(7, 2, 7),
+				Value: &Int64{
+					LiteralPos: mkpos(9, 2, 9),
+					Value:      1000000,
+				},
+				OrigValue: &Int64{
+					LiteralPos: mkpos(9, 2, 9),
+					Value:      1000000,
+				},
+				Assigner:   "=",
+				Referenced: true,
+			},
+			&Assignment{
+				Name:      "bar",
+				NamePos:   mkpos(19, 3, 3),
+				EqualsPos: mkpos(23, 3, 7),
+				Value: &Variable{
+					Name:    "foo",
+					NamePos: mkpos(25, 3, 9),
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      1000000,
+					},
+				},
+				OrigValue: &Variable{
+					Name:    "foo",
+					NamePos: mkpos(25, 3, 9),
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      1000000,
+					},
+				},
+				Assigner:   "=",
+				Referenced: true,
+			},
+			&Assignment{
+				Name:      "baz",
+				NamePos:   mkpos(31, 4, 3),
+				EqualsPos: mkpos(35, 4, 7),
+				Value: &Operator{
+					OperatorPos: mkpos(41, 4, 13),
+					Operator:    '+',
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      2000000,
+					},
+					Args: [2]Expression{
+						&Variable{
+							Name:    "foo",
+							NamePos: mkpos(37, 4, 9),
+							Value: &Int64{
+								LiteralPos: mkpos(9, 2, 9),
+								Value:      1000000,
+							},
+						},
+						&Variable{
+							Name:    "bar",
+							NamePos: mkpos(43, 4, 15),
+							Value: &Variable{
+								Name:    "foo",
+								NamePos: mkpos(25, 3, 9),
+								Value: &Int64{
+									LiteralPos: mkpos(9, 2, 9),
+									Value:      1000000,
+								},
+							},
+						},
+					},
+				},
+				OrigValue: &Operator{
+					OperatorPos: mkpos(41, 4, 13),
+					Operator:    '+',
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      2000000,
+					},
+					Args: [2]Expression{
+						&Variable{
+							Name:    "foo",
+							NamePos: mkpos(37, 4, 9),
+							Value: &Int64{
+								LiteralPos: mkpos(9, 2, 9),
+								Value:      1000000,
+							},
+						},
+						&Variable{
+							Name:    "bar",
+							NamePos: mkpos(43, 4, 15),
+							Value: &Variable{
+								Name:    "foo",
+								NamePos: mkpos(25, 3, 9),
+								Value: &Int64{
+									LiteralPos: mkpos(9, 2, 9),
+									Value:      1000000,
+								},
+							},
+						},
+					},
+				},
+				Assigner:   "=",
+				Referenced: true,
+			},
+			&Assignment{
+				Name:      "boo",
+				NamePos:   mkpos(49, 5, 3),
+				EqualsPos: mkpos(53, 5, 7),
+				Value: &Operator{
+					Args: [2]Expression{
+						&Variable{
+							Name:    "baz",
+							NamePos: mkpos(55, 5, 9),
+							Value: &Operator{
+								OperatorPos: mkpos(41, 4, 13),
+								Operator:    '+',
+								Value: &Int64{
+									LiteralPos: mkpos(9, 2, 9),
+									Value:      2000000,
+								},
+								Args: [2]Expression{
+									&Variable{
+										Name:    "foo",
+										NamePos: mkpos(37, 4, 9),
+										Value: &Int64{
+											LiteralPos: mkpos(9, 2, 9),
+											Value:      1000000,
+										},
+									},
+									&Variable{
+										Name:    "bar",
+										NamePos: mkpos(43, 4, 15),
+										Value: &Variable{
+											Name:    "foo",
+											NamePos: mkpos(25, 3, 9),
+											Value: &Int64{
+												LiteralPos: mkpos(9, 2, 9),
+												Value:      1000000,
+											},
+										},
+									},
+								},
+							},
+						},
+						&Variable{
+							Name:    "foo",
+							NamePos: mkpos(68, 6, 10),
+							Value: &Int64{
+								LiteralPos: mkpos(9, 2, 9),
+								Value:      1000000,
+							},
+						},
+					},
+					OperatorPos: mkpos(66, 6, 8),
+					Operator:    '+',
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      3000000,
+					},
+				},
+				OrigValue: &Variable{
+					Name:    "baz",
+					NamePos: mkpos(55, 5, 9),
+					Value: &Operator{
+						OperatorPos: mkpos(41, 4, 13),
+						Operator:    '+',
+						Value: &Int64{
+							LiteralPos: mkpos(9, 2, 9),
+							Value:      2000000,
+						},
+						Args: [2]Expression{
+							&Variable{
+								Name:    "foo",
+								NamePos: mkpos(37, 4, 9),
+								Value: &Int64{
+									LiteralPos: mkpos(9, 2, 9),
+									Value:      1000000,
+								},
+							},
+							&Variable{
+								Name:    "bar",
+								NamePos: mkpos(43, 4, 15),
+								Value: &Variable{
+									Name:    "foo",
+									NamePos: mkpos(25, 3, 9),
+									Value: &Int64{
+										LiteralPos: mkpos(9, 2, 9),
+										Value:      1000000,
+									},
+								},
+							},
+						},
+					},
+				},
+				Assigner: "=",
+			},
+			&Assignment{
+				Name:      "boo",
+				NamePos:   mkpos(61, 6, 3),
+				EqualsPos: mkpos(66, 6, 8),
+				Value: &Variable{
+					Name:    "foo",
+					NamePos: mkpos(68, 6, 10),
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      1000000,
+					},
+				},
+				OrigValue: &Variable{
+					Name:    "foo",
+					NamePos: mkpos(68, 6, 10),
+					Value: &Int64{
+						LiteralPos: mkpos(9, 2, 9),
+						Value:      1000000,
+					},
+				},
+				Assigner: "+=",
+			},
+		},
+		nil,
+	},
+
 	{`
 		// comment1
 		// comment2

--- a/parser/printer.go
+++ b/parser/printer.go
@@ -123,6 +123,8 @@ func (p *printer) printExpression(value Expression) {
 			s = "false"
 		}
 		p.printToken(s, v.LiteralPos)
+	case *Int64:
+		p.printToken(strconv.FormatInt(v.Value, 10), v.LiteralPos)
 	case *String:
 		p.printToken(strconv.Quote(v.Value), v.LiteralPos)
 	case *List:

--- a/parser/printer_test.go
+++ b/parser/printer_test.go
@@ -33,11 +33,12 @@ foo {}
 	},
 	{
 		input: `
-foo{name= "abc",}
+foo{name= "abc",num= 4,}
 `,
 		output: `
 foo {
     name: "abc",
+    num: 4,
 }
 `,
 	},
@@ -108,7 +109,8 @@ foo {
 		foo {
 			stuff: {
 				isGood: true,
-				name: "bar"
+				name: "bar",
+				num: 4,
 			}
 		}
 		`,
@@ -117,6 +119,7 @@ foo {
     stuff: {
         isGood: true,
         name: "bar",
+        num: 4,
     },
 }
 `,
@@ -141,19 +144,23 @@ foo {
 		input: `
 foo {
 	name: "abc",
+	num: 4,
 }
 
 bar  {
 	name: "def",
+	num: 5,
 }
 		`,
 		output: `
 foo {
     name: "abc",
+    num: 4,
 }
 
 bar {
     name: "def",
+    num: 5,
 }
 `,
 	},
@@ -166,6 +173,20 @@ baz += foo
 `,
 		output: `
 foo = "stuff"
+bar = foo
+baz = foo + bar
+baz += foo
+`,
+	},
+	{
+		input: `
+foo = 100
+bar = foo
+baz = foo + bar
+baz += foo
+`,
+		output: `
+foo = 100
 bar = foo
 baz = foo + bar
 baz += foo

--- a/proptools/clone.go
+++ b/proptools/clone.go
@@ -114,7 +114,7 @@ func CopyProperties(dstValue, srcValue reflect.Value) {
 						origDstFieldValue.Set(newValue)
 					}
 				}
-			case reflect.Bool, reflect.String:
+			case reflect.Bool, reflect.Int64, reflect.String:
 				newValue := reflect.New(srcFieldValue.Type())
 				newValue.Elem().Set(srcFieldValue)
 				origDstFieldValue.Set(newValue)
@@ -167,7 +167,7 @@ func ZeroProperties(structValue reflect.Value) {
 					break
 				}
 				ZeroProperties(fieldValue.Elem())
-			case reflect.Bool, reflect.String:
+			case reflect.Bool, reflect.Int64, reflect.String:
 				fieldValue.Set(reflect.Zero(fieldValue.Type()))
 			default:
 				panic(fmt.Errorf("can't zero field %q: points to a %s",
@@ -237,7 +237,7 @@ func cloneEmptyProperties(dstValue, srcValue reflect.Value) {
 				} else {
 					dstFieldValue.Set(newValue)
 				}
-			case reflect.Bool, reflect.String:
+			case reflect.Bool, reflect.Int64, reflect.String:
 				// Nothing
 			default:
 				panic(fmt.Errorf("can't clone empty field %q: points to a %s",

--- a/proptools/clone_test.go
+++ b/proptools/clone_test.go
@@ -91,6 +91,15 @@ var clonePropertiesTestCases = []struct {
 		},
 	},
 	{
+		// Clone pointer to int64
+		in: &struct{ S *int64 }{
+			S: Int64Ptr(5),
+		},
+		out: &struct{ S *int64 }{
+			S: Int64Ptr(5),
+		},
+	},
+	{
 		// Clone struct
 		in: &struct{ S struct{ S string } }{
 			S: struct{ S string }{
@@ -189,10 +198,12 @@ var clonePropertiesTestCases = []struct {
 		}{
 			EmbeddedStruct: EmbeddedStruct{
 				S: "string1",
+				I: Int64Ptr(55),
 			},
 			Nested: struct{ EmbeddedStruct }{
 				EmbeddedStruct: EmbeddedStruct{
 					S: "string2",
+					I: Int64Ptr(5),
 				},
 			},
 		},
@@ -202,10 +213,12 @@ var clonePropertiesTestCases = []struct {
 		}{
 			EmbeddedStruct: EmbeddedStruct{
 				S: "string1",
+				I: Int64Ptr(55),
 			},
 			Nested: struct{ EmbeddedStruct }{
 				EmbeddedStruct: EmbeddedStruct{
 					S: "string2",
+					I: Int64Ptr(5),
 				},
 			},
 		},
@@ -241,7 +254,10 @@ var clonePropertiesTestCases = []struct {
 	},
 }
 
-type EmbeddedStruct struct{ S string }
+type EmbeddedStruct struct {
+	S string
+	I *int64
+}
 type EmbeddedInterface interface{}
 
 func TestCloneProperties(t *testing.T) {
@@ -307,6 +323,14 @@ var cloneEmptyPropertiesTestCases = []struct {
 			B2: BoolPtr(false),
 		},
 		out: &struct{ B1, B2 *bool }{},
+	},
+	{
+		// Clone pointer to int64
+		in: &struct{ B1, B2 *int64 }{
+			B1: Int64Ptr(5),
+			B2: Int64Ptr(4),
+		},
+		out: &struct{ B1, B2 *int64 }{},
 	},
 	{
 		// Clone pointer to string

--- a/proptools/extend.go
+++ b/proptools/extend.go
@@ -346,7 +346,7 @@ func extendPropertiesRecursive(dstValues []reflect.Value, srcValue reflect.Value
 						dstFieldValue.Type(), srcFieldValue.Type())
 				}
 				switch ptrKind := srcFieldValue.Type().Elem().Kind(); ptrKind {
-				case reflect.Bool, reflect.String, reflect.Struct:
+				case reflect.Bool, reflect.Int64, reflect.String, reflect.Struct:
 				// Nothing
 				default:
 					return extendPropertyErrorf(propertyName, "pointer is a %s", ptrKind)
@@ -447,6 +447,17 @@ func ExtendBasicType(dstFieldValue, srcFieldValue reflect.Value, order Order) {
 			} else {
 				// For append, replace the original value.
 				dstFieldValue.Set(reflect.ValueOf(BoolPtr(srcFieldValue.Elem().Bool())))
+			}
+		case reflect.Int64:
+			if prepend {
+				if dstFieldValue.IsNil() {
+					// Int() returns Int64
+					dstFieldValue.Set(reflect.ValueOf(Int64Ptr(srcFieldValue.Elem().Int())))
+				}
+			} else {
+				// For append, replace the original value.
+				// Int() returns Int64
+				dstFieldValue.Set(reflect.ValueOf(Int64Ptr(srcFieldValue.Elem().Int())))
 			}
 		case reflect.String:
 			if prepend {

--- a/proptools/extend_test.go
+++ b/proptools/extend_test.go
@@ -177,6 +177,58 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			prepend: true,
 		},
 		{
+			// Append pointer to integer
+			in1: &struct{ I1, I2, I3, I4, I5, I6, I7, I8, I9 *int64 }{
+				I1: Int64Ptr(55),
+				I2: Int64Ptr(-3),
+				I3: nil,
+				I4: Int64Ptr(100),
+				I5: Int64Ptr(33),
+				I6: nil,
+				I7: Int64Ptr(77),
+				I8: Int64Ptr(0),
+				I9: nil,
+			},
+			in2: &struct{ I1, I2, I3, I4, I5, I6, I7, I8, I9 *int64 }{
+				I1: nil,
+				I2: nil,
+				I3: nil,
+				I4: Int64Ptr(1),
+				I5: Int64Ptr(-2),
+				I6: Int64Ptr(8),
+				I7: Int64Ptr(9),
+				I8: Int64Ptr(10),
+				I9: Int64Ptr(11),
+			},
+			out: &struct{ I1, I2, I3, I4, I5, I6, I7, I8, I9 *int64 }{
+				I1: Int64Ptr(55),
+				I2: Int64Ptr(-3),
+				I3: nil,
+				I4: Int64Ptr(1),
+				I5: Int64Ptr(-2),
+				I6: Int64Ptr(8),
+				I7: Int64Ptr(9),
+				I8: Int64Ptr(10),
+				I9: Int64Ptr(11),
+			},
+		},
+		{
+			// Prepend pointer to integer
+			in1: &struct{ I1, I2, I3 *int64 }{
+				I1: Int64Ptr(55),
+				I3: nil,
+			},
+			in2: &struct{ I1, I2, I3 *int64 }{
+				I2: Int64Ptr(33),
+			},
+			out: &struct{ I1, I2, I3 *int64 }{
+				I1: Int64Ptr(55),
+				I2: Int64Ptr(33),
+				I3: nil,
+			},
+			prepend: true,
+		},
+		{
 			// Append pointer to strings
 			in1: &struct{ S1, S2, S3, S4 *string }{
 				S1: StringPtr("string1"),
@@ -383,6 +435,18 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			},
 		},
 		{
+			// Unexported field
+			in1: &struct{ i *int64 }{
+				i: Int64Ptr(33),
+			},
+			in2: &struct{ i *int64 }{
+				i: Int64Ptr(5),
+			},
+			out: &struct{ i *int64 }{
+				i: Int64Ptr(33),
+			},
+		},
+		{
 			// Empty struct
 			in1: &struct{}{},
 			in2: &struct{}{},
@@ -420,10 +484,12 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			}{
 				EmbeddedStruct: EmbeddedStruct{
 					S: "string1",
+					I: Int64Ptr(55),
 				},
 				Nested: struct{ EmbeddedStruct }{
 					EmbeddedStruct: EmbeddedStruct{
 						S: "string2",
+						I: Int64Ptr(-4),
 					},
 				},
 			},
@@ -433,10 +499,12 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			}{
 				EmbeddedStruct: EmbeddedStruct{
 					S: "string3",
+					I: Int64Ptr(66),
 				},
 				Nested: struct{ EmbeddedStruct }{
 					EmbeddedStruct: EmbeddedStruct{
 						S: "string4",
+						I: Int64Ptr(-8),
 					},
 				},
 			},
@@ -446,10 +514,12 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			}{
 				EmbeddedStruct: EmbeddedStruct{
 					S: "string1string3",
+					I: Int64Ptr(66),
 				},
 				Nested: struct{ EmbeddedStruct }{
 					EmbeddedStruct: EmbeddedStruct{
 						S: "string2string4",
+						I: Int64Ptr(-8),
 					},
 				},
 			},
@@ -460,12 +530,20 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				EmbeddedInterface
 				Nested struct{ EmbeddedInterface }
 			}{
-				EmbeddedInterface: &struct{ S string }{
+				EmbeddedInterface: &struct {
+					S string
+					I *int64
+				}{
 					S: "string1",
+					I: Int64Ptr(-8),
 				},
 				Nested: struct{ EmbeddedInterface }{
-					EmbeddedInterface: &struct{ S string }{
+					EmbeddedInterface: &struct {
+						S string
+						I *int64
+					}{
 						S: "string2",
+						I: Int64Ptr(55),
 					},
 				},
 			},
@@ -473,12 +551,20 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				EmbeddedInterface
 				Nested struct{ EmbeddedInterface }
 			}{
-				EmbeddedInterface: &struct{ S string }{
+				EmbeddedInterface: &struct {
+					S string
+					I *int64
+				}{
 					S: "string3",
+					I: Int64Ptr(6),
 				},
 				Nested: struct{ EmbeddedInterface }{
-					EmbeddedInterface: &struct{ S string }{
+					EmbeddedInterface: &struct {
+						S string
+						I *int64
+					}{
 						S: "string4",
+						I: Int64Ptr(6),
 					},
 				},
 			},
@@ -486,12 +572,20 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				EmbeddedInterface
 				Nested struct{ EmbeddedInterface }
 			}{
-				EmbeddedInterface: &struct{ S string }{
+				EmbeddedInterface: &struct {
+					S string
+					I *int64
+				}{
 					S: "string1string3",
+					I: Int64Ptr(6),
 				},
 				Nested: struct{ EmbeddedInterface }{
-					EmbeddedInterface: &struct{ S string }{
+					EmbeddedInterface: &struct {
+						S string
+						I *int64
+					}{
 						S: "string2string4",
+						I: Int64Ptr(6),
 					},
 				},
 			},
@@ -624,6 +718,19 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				I: 1,
 			},
 			err: extendPropertyErrorf("i", "unsupported kind int"),
+		},
+		{
+			// Unsupported kind
+			in1: &struct{ I int64 }{
+				I: 1,
+			},
+			in2: &struct{ I int64 }{
+				I: 2,
+			},
+			out: &struct{ I int64 }{
+				I: 1,
+			},
+			err: extendPropertyErrorf("i", "unsupported kind int64"),
 		},
 		{
 			// Interface nilitude mismatch
@@ -782,6 +889,24 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				S string `blueprint:"mutated"`
 			}{
 				S: "string1",
+			},
+		},
+		{
+			// Filter mutated
+			in1: &struct {
+				S *int64 `blueprint:"mutated"`
+			}{
+				S: Int64Ptr(4),
+			},
+			in2: &struct {
+				S *int64 `blueprint:"mutated"`
+			}{
+				S: Int64Ptr(5),
+			},
+			out: &struct {
+				S *int64 `blueprint:"mutated"`
+			}{
+				S: Int64Ptr(4),
 			},
 		},
 		{

--- a/proptools/proptools.go
+++ b/proptools/proptools.go
@@ -55,6 +55,12 @@ func BoolPtr(b bool) *bool {
 	return &b
 }
 
+// Int64Ptr returns a pointer to a new int64 containing the given value.
+func Int64Ptr(i int64) *int64 {
+	b := int64(i)
+	return &(b)
+}
+
 // StringPtr returns a pointer to a new string containing the given value.
 func StringPtr(s string) *string {
 	return &s

--- a/unpack.go
+++ b/unpack.go
@@ -186,7 +186,7 @@ func unpackStructValue(namePrefix string, structValue reflect.Value,
 					origFieldValue.Set(fieldValue)
 				}
 				fieldValue = fieldValue.Elem()
-			case reflect.Bool, reflect.String:
+			case reflect.Bool, reflect.Int64, reflect.String:
 				// Nothing
 			default:
 				panic(fmt.Errorf("field %s contains a pointer to %s", propertyName, ptrKind))
@@ -299,6 +299,14 @@ func propertyToValue(typ reflect.Type, property *parser.Property) (reflect.Value
 		b, ok := property.Value.Eval().(*parser.Bool)
 		if !ok {
 			return value, fmt.Errorf("%s: can't assign %s value to bool property %q",
+				property.Value.Pos(), property.Value.Type(), property.Name)
+		}
+		value = reflect.ValueOf(b.Value)
+
+	case reflect.Int64:
+		b, ok := property.Value.Eval().(*parser.Int64)
+		if !ok {
+			return value, fmt.Errorf("%s: can't assign %s value to int64 property %q",
 				property.Value.Pos(), property.Value.Type(), property.Name)
 		}
 		value = reflect.ValueOf(b.Value)


### PR DESCRIPTION
Support int64 number instead of int to be more fixed to num of bits so that the underlying arch won't affect overflow cases. Besides, refection: func (v Value) Int() int64 always cast to int64 no matter the input is int, int16, int32. Currently we always treat "-" as negative sign to bind to next value, and "+" as plus operator to add operands together.
So we allow:
a = 5 + -4 + 5 or a = -4 + 5
But we don't allow:
a = +5 + 4 + -4 since we don't treat "+" as a positive sign, otherwise,
a = 5 + +5 would exist which looks pretty weird. In the future, we may want fully support number calculator logic eg, "+"/"-" can be positive/negative sign or operator, and "(" and ")" will be considered to group expressions with a higher precedence.

int & uint properties within struct keeps unchanged, which is only allowed when tagged with 'blueprint:mutated'. We only allow ***int64** property instead of int64 property within struct since it does't make sense to do prepending or appending to int64. 