### PR TITLE
Update microfactory compile error message to show the command that fa…

### DIFF
--- a/microfactory/microfactory.go
+++ b/microfactory/microfactory.go
@@ -409,7 +409,8 @@ func (p *GoPackage) Compile(config *Config, outDir string) error {
 	}
 	err = cmd.Run()
 	if err != nil {
-		err = fmt.Errorf("%s: %v", p.Name, err)
+		commandText := strings.Join(cmd.Args, " ")
+		err = fmt.Errorf("%q: %v", commandText, err)
 		p.failed = err
 		return err
 	}
@@ -511,13 +512,13 @@ func Build(config *Config, out, pkg string) (*GoPackage, error) {
 	}
 
 	if err := p.FindDeps(config, path); err != nil {
-		return nil, fmt.Errorf("Failed to find deps: %v", err)
+		return nil, fmt.Errorf("Failed to find deps of %v: %v", pkg, err)
 	}
 	if err := p.Compile(config, intermediates); err != nil {
-		return nil, fmt.Errorf("Failed to compile: %v", err)
+		return nil, fmt.Errorf("Failed to compile %v: %v", pkg, err)
 	}
 	if err := p.Link(config, out); err != nil {
-		return nil, fmt.Errorf("Failed to link: %v", err)
+		return nil, fmt.Errorf("Failed to link %v: %v", pkg, err)
 	}
 	return p, nil
 }


### PR DESCRIPTION
…iled

Easier to debug than "Failed to compile: main: exit status 2"

Bug: 68770962
Test: sed -i 's/build.FindSources/files := build.FindSources/' build/soong/cmd/soong_ui/main.go \
      && m -j nothing

Change-Id: If78a4fa1c3999e7c658dce072c05d7d3e23b8683