### PR TITLE
Don't allow user to define string, and bool properties within module struct

### DIFF
--- a/bootstrap/writedocs.go
+++ b/bootstrap/writedocs.go
@@ -18,7 +18,7 @@ func writeDocs(ctx *blueprint.Context, srcDir, filename string) error {
 	ctx.VisitAllModulesIf(isBootstrapBinaryModule,
 		func(module blueprint.Module) {
 			binaryModule := module.(*goBinary)
-			if binaryModule.properties.PrimaryBuilder {
+			if Bool(binaryModule.properties.PrimaryBuilder) {
 				primaryBuilders = append(primaryBuilders, binaryModule)
 			}
 			if ctx.ModuleName(binaryModule) == "minibp" {
@@ -48,7 +48,7 @@ func writeDocs(ctx *blueprint.Context, srcDir, filename string) error {
 	ctx.VisitDepsDepthFirst(primaryBuilder, func(module blueprint.Module) {
 		switch m := module.(type) {
 		case (*goPackage):
-			pkgFiles[m.properties.PkgPath] = pathtools.PrefixPaths(m.properties.Srcs,
+			pkgFiles[String(m.properties.PkgPath)] = pathtools.PrefixPaths(m.properties.Srcs,
 				filepath.Join(srcDir, ctx.ModuleDir(m)))
 		default:
 			panic(fmt.Errorf("unknown dependency type %T", module))

--- a/context_test.go
+++ b/context_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/blueprint/parser"
+	"github.com/google/blueprint/proptools"
 )
 
 type Walker interface {
@@ -30,7 +31,7 @@ type fooModule struct {
 	SimpleName
 	properties struct {
 		Deps []string
-		Foo  string
+		Foo  *string
 	}
 }
 
@@ -47,7 +48,7 @@ func (f *fooModule) DynamicDependencies(ctx DynamicDependerModuleContext) []stri
 }
 
 func (f *fooModule) Foo() string {
-	return f.properties.Foo
+	return String(f.properties.Foo)
 }
 
 func (f *fooModule) Walk() bool {
@@ -58,7 +59,7 @@ type barModule struct {
 	SimpleName
 	properties struct {
 		Deps []string
-		Bar  bool
+		Bar  *bool
 	}
 }
 
@@ -75,7 +76,7 @@ func (b *barModule) GenerateBuildActions(ModuleContext) {
 }
 
 func (b *barModule) Bar() bool {
-	return b.properties.Bar
+	return Bool(b.properties.Bar)
 }
 
 func (b *barModule) Walk() bool {
@@ -264,21 +265,26 @@ func TestCreateModule(t *testing.T) {
 
 func createTestMutator(ctx TopDownMutatorContext) {
 	type props struct {
-		Name string
+		Name *string
 		Deps []string
 	}
 
 	ctx.CreateModule(newBarModule, &props{
-		Name: "B",
+		Name: StringPtr("B"),
 		Deps: []string{"D"},
 	})
 
 	ctx.CreateModule(newBarModule, &props{
-		Name: "C",
+		Name: StringPtr("C"),
 		Deps: []string{"D"},
 	})
 
 	ctx.CreateModule(newFooModule, &props{
-		Name: "D",
+		Name: StringPtr("D"),
 	})
 }
+
+var StringPtr = proptools.StringPtr
+var String = proptools.String
+var Bool = proptools.Bool
+var BoolPtr = proptools.BoolPtr

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -763,10 +763,10 @@ func (mctx *mutatorContext) CreateModule(factory ModuleFactory, props ...interfa
 // structure list.
 type SimpleName struct {
 	Properties struct {
-		Name string
+		Name *string
 	}
 }
 
 func (s *SimpleName) Name() string {
-	return s.Properties.Name
+	return proptools.String(s.Properties.Name)
 }

--- a/proptools/clone_test.go
+++ b/proptools/clone_test.go
@@ -197,12 +197,12 @@ var clonePropertiesTestCases = []struct {
 			Nested struct{ EmbeddedStruct }
 		}{
 			EmbeddedStruct: EmbeddedStruct{
-				S: "string1",
+				S: StringPtr("string1"),
 				I: Int64Ptr(55),
 			},
 			Nested: struct{ EmbeddedStruct }{
 				EmbeddedStruct: EmbeddedStruct{
-					S: "string2",
+					S: StringPtr("string2"),
 					I: Int64Ptr(5),
 				},
 			},
@@ -212,12 +212,12 @@ var clonePropertiesTestCases = []struct {
 			Nested struct{ EmbeddedStruct }
 		}{
 			EmbeddedStruct: EmbeddedStruct{
-				S: "string1",
+				S: StringPtr("string1"),
 				I: Int64Ptr(55),
 			},
 			Nested: struct{ EmbeddedStruct }{
 				EmbeddedStruct: EmbeddedStruct{
-					S: "string2",
+					S: StringPtr("string2"),
 					I: Int64Ptr(5),
 				},
 			},
@@ -255,7 +255,7 @@ var clonePropertiesTestCases = []struct {
 }
 
 type EmbeddedStruct struct {
-	S string
+	S *string
 	I *int64
 }
 type EmbeddedInterface interface{}
@@ -426,11 +426,11 @@ var cloneEmptyPropertiesTestCases = []struct {
 			Nested struct{ EmbeddedStruct }
 		}{
 			EmbeddedStruct: EmbeddedStruct{
-				S: "string1",
+				S: StringPtr("string1"),
 			},
 			Nested: struct{ EmbeddedStruct }{
 				EmbeddedStruct: EmbeddedStruct{
-					S: "string2",
+					S: StringPtr("string2"),
 				},
 			},
 		},

--- a/proptools/extend.go
+++ b/proptools/extend.go
@@ -335,7 +335,7 @@ func extendPropertiesRecursive(dstValues []reflect.Value, srcValue reflect.Value
 				// Recursively extend the struct's fields.
 				recurse = append(recurse, dstFieldValue)
 				continue
-			case reflect.Bool, reflect.String, reflect.Slice:
+			case reflect.Slice:
 				if srcFieldValue.Type() != dstFieldValue.Type() {
 					return extendPropertyErrorf(propertyName, "mismatched types %s and %s",
 						dstFieldValue.Type(), srcFieldValue.Type())
@@ -407,17 +407,6 @@ func ExtendBasicType(dstFieldValue, srcFieldValue reflect.Value, order Order) {
 	prepend := order == Prepend
 
 	switch srcFieldValue.Kind() {
-	case reflect.Bool:
-		// Boolean OR
-		dstFieldValue.Set(reflect.ValueOf(srcFieldValue.Bool() || dstFieldValue.Bool()))
-	case reflect.String:
-		if prepend {
-			dstFieldValue.SetString(srcFieldValue.String() +
-				dstFieldValue.String())
-		} else {
-			dstFieldValue.SetString(dstFieldValue.String() +
-				srcFieldValue.String())
-		}
 	case reflect.Slice:
 		if srcFieldValue.IsNil() {
 			break

--- a/proptools/extend_test.go
+++ b/proptools/extend_test.go
@@ -36,74 +36,6 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 		// Valid inputs
 
 		{
-			// Append bool
-			in1: &struct{ B1, B2, B3, B4 bool }{
-				B1: true,
-				B2: false,
-				B3: true,
-				B4: false,
-			},
-			in2: &struct{ B1, B2, B3, B4 bool }{
-				B1: true,
-				B2: true,
-				B3: false,
-				B4: false,
-			},
-			out: &struct{ B1, B2, B3, B4 bool }{
-				B1: true,
-				B2: true,
-				B3: true,
-				B4: false,
-			},
-		},
-		{
-			// Prepend bool
-			in1: &struct{ B1, B2, B3, B4 bool }{
-				B1: true,
-				B2: false,
-				B3: true,
-				B4: false,
-			},
-			in2: &struct{ B1, B2, B3, B4 bool }{
-				B1: true,
-				B2: true,
-				B3: false,
-				B4: false,
-			},
-			out: &struct{ B1, B2, B3, B4 bool }{
-				B1: true,
-				B2: true,
-				B3: true,
-				B4: false,
-			},
-			prepend: true,
-		},
-		{
-			// Append strings
-			in1: &struct{ S string }{
-				S: "string1",
-			},
-			in2: &struct{ S string }{
-				S: "string2",
-			},
-			out: &struct{ S string }{
-				S: "string1string2",
-			},
-		},
-		{
-			// Prepend strings
-			in1: &struct{ S string }{
-				S: "string1",
-			},
-			in2: &struct{ S string }{
-				S: "string2",
-			},
-			out: &struct{ S string }{
-				S: "string2string1",
-			},
-			prepend: true,
-		},
-		{
 			// Append pointer to bool
 			in1: &struct{ B1, B2, B3, B4, B5, B6, B7, B8, B9 *bool }{
 				B1: BoolPtr(true),
@@ -350,37 +282,37 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 		},
 		{
 			// Append pointer
-			in1: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string1",
+			in1: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
-			in2: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string2",
+			in2: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
-			out: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string1string2",
+			out: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
 		},
 		{
 			// Prepend pointer
-			in1: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string1",
+			in1: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
-			in2: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string2",
+			in2: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
-			out: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string2string1",
+			out: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
 			prepend: true,
@@ -388,50 +320,50 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 		{
 			// Append interface
 			in1: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string1",
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
 			in2: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string2",
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
 			out: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string1string2",
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
 		},
 		{
 			// Prepend interface
 			in1: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string1",
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
 			in2: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string2",
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
 			out: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string2string1",
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
 			prepend: true,
 		},
 		{
 			// Unexported field
-			in1: &struct{ s string }{
-				s: "string1",
+			in1: &struct{ s *string }{
+				s: StringPtr("string1"),
 			},
-			in2: &struct{ s string }{
-				s: "string2",
+			in2: &struct{ s *string }{
+				s: StringPtr("string2"),
 			},
-			out: &struct{ s string }{
-				s: "string1",
+			out: &struct{ s *string }{
+				s: StringPtr("string1"),
 			},
 		},
 		{
@@ -483,12 +415,12 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				Nested struct{ EmbeddedStruct }
 			}{
 				EmbeddedStruct: EmbeddedStruct{
-					S: "string1",
+					S: StringPtr("string1"),
 					I: Int64Ptr(55),
 				},
 				Nested: struct{ EmbeddedStruct }{
 					EmbeddedStruct: EmbeddedStruct{
-						S: "string2",
+						S: StringPtr("string2"),
 						I: Int64Ptr(-4),
 					},
 				},
@@ -498,12 +430,12 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				Nested struct{ EmbeddedStruct }
 			}{
 				EmbeddedStruct: EmbeddedStruct{
-					S: "string3",
+					S: StringPtr("string3"),
 					I: Int64Ptr(66),
 				},
 				Nested: struct{ EmbeddedStruct }{
 					EmbeddedStruct: EmbeddedStruct{
-						S: "string4",
+						S: StringPtr("string4"),
 						I: Int64Ptr(-8),
 					},
 				},
@@ -513,12 +445,12 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				Nested struct{ EmbeddedStruct }
 			}{
 				EmbeddedStruct: EmbeddedStruct{
-					S: "string1string3",
+					S: StringPtr("string3"),
 					I: Int64Ptr(66),
 				},
 				Nested: struct{ EmbeddedStruct }{
 					EmbeddedStruct: EmbeddedStruct{
-						S: "string2string4",
+						S: StringPtr("string4"),
 						I: Int64Ptr(-8),
 					},
 				},
@@ -531,18 +463,18 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				Nested struct{ EmbeddedInterface }
 			}{
 				EmbeddedInterface: &struct {
-					S string
+					S *string
 					I *int64
 				}{
-					S: "string1",
+					S: StringPtr("string1"),
 					I: Int64Ptr(-8),
 				},
 				Nested: struct{ EmbeddedInterface }{
 					EmbeddedInterface: &struct {
-						S string
+						S *string
 						I *int64
 					}{
-						S: "string2",
+						S: StringPtr("string2"),
 						I: Int64Ptr(55),
 					},
 				},
@@ -552,18 +484,18 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				Nested struct{ EmbeddedInterface }
 			}{
 				EmbeddedInterface: &struct {
-					S string
+					S *string
 					I *int64
 				}{
-					S: "string3",
+					S: StringPtr("string3"),
 					I: Int64Ptr(6),
 				},
 				Nested: struct{ EmbeddedInterface }{
 					EmbeddedInterface: &struct {
-						S string
+						S *string
 						I *int64
 					}{
-						S: "string4",
+						S: StringPtr("string4"),
 						I: Int64Ptr(6),
 					},
 				},
@@ -573,18 +505,18 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				Nested struct{ EmbeddedInterface }
 			}{
 				EmbeddedInterface: &struct {
-					S string
+					S *string
 					I *int64
 				}{
-					S: "string1string3",
+					S: StringPtr("string3"),
 					I: Int64Ptr(6),
 				},
 				Nested: struct{ EmbeddedInterface }{
 					EmbeddedInterface: &struct {
-						S string
+						S *string
 						I *int64
 					}{
-						S: "string2string4",
+						S: StringPtr("string4"),
 						I: Int64Ptr(6),
 					},
 				},
@@ -594,29 +526,29 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			// Nil pointer to a struct
 			in1: &struct {
 				Nested *struct {
-					S string
+					S *string
 				}
 			}{},
 			in2: &struct {
 				Nested *struct {
-					S string
+					S *string
 				}
 			}{
 				Nested: &struct {
-					S string
+					S *string
 				}{
-					S: "string",
+					S: StringPtr("string"),
 				},
 			},
 			out: &struct {
 				Nested *struct {
-					S string
+					S *string
 				}
 			}{
 				Nested: &struct {
-					S string
+					S *string
 				}{
-					S: "string",
+					S: StringPtr("string"),
 				},
 			},
 		},
@@ -625,45 +557,45 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			in1: &struct {
 				Nested interface{}
 			}{
-				Nested: (*struct{ S string })(nil),
+				Nested: (*struct{ S *string })(nil),
 			},
 			in2: &struct {
 				Nested interface{}
 			}{
 				Nested: &struct {
-					S string
+					S *string
 				}{
-					S: "string",
+					S: StringPtr("string"),
 				},
 			},
 			out: &struct {
 				Nested interface{}
 			}{
 				Nested: &struct {
-					S string
+					S *string
 				}{
-					S: "string",
+					S: StringPtr("string"),
 				},
 			},
 		},
 		{
 			// Interface src nil
 			in1: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string1",
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
 			in2: &struct{ S interface{} }{
 				S: nil,
 			},
 			out: &struct{ S interface{} }{
-				S: &struct{ S string }{
-					S: "string1",
+				S: &struct{ S *string }{
+					S: StringPtr("string1"),
 				},
 			},
 		},
 
-		// Errors
+		//// Errors
 
 		{
 			// Non-pointer in1
@@ -818,18 +750,18 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 			err: extendPropertyErrorf("s.i", "unsupported kind int"),
 		},
 
-		// Filters
+		//// Filters
 
 		{
 			// Filter true
-			in1: &struct{ S string }{
-				S: "string1",
+			in1: &struct{ S *string }{
+				S: StringPtr("string1"),
 			},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: &struct{ S string }{
-				S: "string1string2",
+			out: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
 			filter: func(property string,
 				dstField, srcField reflect.StructField,
@@ -839,14 +771,14 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 		},
 		{
 			// Filter false
-			in1: &struct{ S string }{
-				S: "string1",
+			in1: &struct{ S *string }{
+				S: StringPtr("string1"),
 			},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: &struct{ S string }{
-				S: "string1",
+			out: &struct{ S *string }{
+				S: StringPtr("string1"),
 			},
 			filter: func(property string,
 				dstField, srcField reflect.StructField,
@@ -856,21 +788,21 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 		},
 		{
 			// Filter check args
-			in1: &struct{ S string }{
-				S: "string1",
+			in1: &struct{ S *string }{
+				S: StringPtr("string1"),
 			},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: &struct{ S string }{
-				S: "string1string2",
+			out: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
 			filter: func(property string,
 				dstField, srcField reflect.StructField,
 				dstValue, srcValue interface{}) (bool, error) {
 				return property == "s" &&
 					dstField.Name == "S" && srcField.Name == "S" &&
-					dstValue.(string) == "string1" && srcValue.(string) == "string2", nil
+					*(dstValue.(*string)) == "string1" && *(srcValue.(*string)) == "string2", nil
 			},
 		},
 		{
@@ -911,14 +843,14 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 		},
 		{
 			// Filter error
-			in1: &struct{ S string }{
-				S: "string1",
+			in1: &struct{ S *string }{
+				S: StringPtr("string1"),
 			},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: &struct{ S string }{
-				S: "string1",
+			out: &struct{ S *string }{
+				S: StringPtr("string1"),
 			},
 			filter: func(property string,
 				dstField, srcField reflect.StructField,
@@ -993,119 +925,119 @@ func appendMatchingPropertiesTestCases() []appendMatchingPropertiesTestCase {
 	return []appendMatchingPropertiesTestCase{
 		{
 			// Append strings
-			in1: []interface{}{&struct{ S string }{
-				S: "string1",
+			in1: []interface{}{&struct{ S *string }{
+				S: StringPtr("string1"),
 			}},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: []interface{}{&struct{ S string }{
-				S: "string1string2",
+			out: []interface{}{&struct{ S *string }{
+				S: StringPtr("string2"),
 			}},
 		},
 		{
 			// Prepend strings
-			in1: []interface{}{&struct{ S string }{
-				S: "string1",
+			in1: []interface{}{&struct{ S *string }{
+				S: StringPtr("string1"),
 			}},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: []interface{}{&struct{ S string }{
-				S: "string2string1",
+			out: []interface{}{&struct{ S *string }{
+				S: StringPtr("string1"),
 			}},
 			prepend: true,
 		},
 		{
 			// Append all
 			in1: []interface{}{
-				&struct{ S, A string }{
-					S: "string1",
+				&struct{ S, A *string }{
+					S: StringPtr("string1"),
 				},
-				&struct{ S, B string }{
-					S: "string2",
+				&struct{ S, B *string }{
+					S: StringPtr("string2"),
 				},
 			},
-			in2: &struct{ S string }{
-				S: "string3",
+			in2: &struct{ S *string }{
+				S: StringPtr("string3"),
 			},
 			out: []interface{}{
-				&struct{ S, A string }{
-					S: "string1string3",
+				&struct{ S, A *string }{
+					S: StringPtr("string3"),
 				},
-				&struct{ S, B string }{
-					S: "string2string3",
+				&struct{ S, B *string }{
+					S: StringPtr("string3"),
 				},
 			},
 		},
 		{
 			// Append some
 			in1: []interface{}{
-				&struct{ S, A string }{
-					S: "string1",
+				&struct{ S, A *string }{
+					S: StringPtr("string1"),
 				},
-				&struct{ B string }{},
+				&struct{ B *string }{},
 			},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
 			out: []interface{}{
-				&struct{ S, A string }{
-					S: "string1string2",
+				&struct{ S, A *string }{
+					S: StringPtr("string2"),
 				},
-				&struct{ B string }{},
+				&struct{ B *string }{},
 			},
 		},
 		{
 			// Append mismatched structs
-			in1: []interface{}{&struct{ S, A string }{
-				S: "string1",
+			in1: []interface{}{&struct{ S, A *string }{
+				S: StringPtr("string1"),
 			}},
-			in2: &struct{ S string }{
-				S: "string2",
+			in2: &struct{ S *string }{
+				S: StringPtr("string2"),
 			},
-			out: []interface{}{&struct{ S, A string }{
-				S: "string1string2",
+			out: []interface{}{&struct{ S, A *string }{
+				S: StringPtr("string2"),
 			}},
 		},
 		{
 			// Append mismatched pointer structs
-			in1: []interface{}{&struct{ S *struct{ S, A string } }{
-				S: &struct{ S, A string }{
-					S: "string1",
+			in1: []interface{}{&struct{ S *struct{ S, A *string } }{
+				S: &struct{ S, A *string }{
+					S: StringPtr("string1"),
 				},
 			}},
-			in2: &struct{ S *struct{ S string } }{
-				S: &struct{ S string }{
-					S: "string2",
+			in2: &struct{ S *struct{ S *string } }{
+				S: &struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
-			out: []interface{}{&struct{ S *struct{ S, A string } }{
-				S: &struct{ S, A string }{
-					S: "string1string2",
+			out: []interface{}{&struct{ S *struct{ S, A *string } }{
+				S: &struct{ S, A *string }{
+					S: StringPtr("string2"),
 				},
 			}},
 		},
 		{
 			// Append through mismatched types
 			in1: []interface{}{
-				&struct{ B string }{},
+				&struct{ B *string }{},
 				&struct{ S interface{} }{
-					S: &struct{ S, A string }{
-						S: "string1",
+					S: &struct{ S, A *string }{
+						S: StringPtr("string1"),
 					},
 				},
 			},
-			in2: &struct{ S struct{ S string } }{
-				S: struct{ S string }{
-					S: "string2",
+			in2: &struct{ S struct{ S *string } }{
+				S: struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
 			out: []interface{}{
-				&struct{ B string }{},
+				&struct{ B *string }{},
 				&struct{ S interface{} }{
-					S: &struct{ S, A string }{
-						S: "string1string2",
+					S: &struct{ S, A *string }{
+						S: StringPtr("string2"),
 					},
 				},
 			},
@@ -1113,21 +1045,21 @@ func appendMatchingPropertiesTestCases() []appendMatchingPropertiesTestCase {
 		{
 			// Append through mismatched types and nil
 			in1: []interface{}{
-				&struct{ B string }{},
+				&struct{ B *string }{},
 				&struct{ S interface{} }{
-					S: (*struct{ S, A string })(nil),
+					S: (*struct{ S, A *string })(nil),
 				},
 			},
-			in2: &struct{ S struct{ S string } }{
-				S: struct{ S string }{
-					S: "string2",
+			in2: &struct{ S struct{ S *string } }{
+				S: struct{ S *string }{
+					S: StringPtr("string2"),
 				},
 			},
 			out: []interface{}{
-				&struct{ B string }{},
+				&struct{ B *string }{},
 				&struct{ S interface{} }{
-					S: &struct{ S, A string }{
-						S: "string2",
+					S: &struct{ S, A *string }{
+						S: StringPtr("string2"),
 					},
 				},
 			},
@@ -1136,45 +1068,45 @@ func appendMatchingPropertiesTestCases() []appendMatchingPropertiesTestCase {
 			// Append through multiple matches
 			in1: []interface{}{
 				&struct {
-					S struct{ S, A string }
+					S struct{ S, A *string }
 				}{
-					S: struct{ S, A string }{
-						S: "string1",
+					S: struct{ S, A *string }{
+						S: StringPtr("string1"),
 					},
 				},
 				&struct {
-					S struct{ S, B string }
+					S struct{ S, B *string }
 				}{
-					S: struct{ S, B string }{
-						S: "string2",
+					S: struct{ S, B *string }{
+						S: StringPtr("string2"),
 					},
 				},
 			},
-			in2: &struct{ S struct{ B string } }{
-				S: struct{ B string }{
-					B: "string3",
+			in2: &struct{ S struct{ B *string } }{
+				S: struct{ B *string }{
+					B: StringPtr("string3"),
 				},
 			},
 			out: []interface{}{
 				&struct {
-					S struct{ S, A string }
+					S struct{ S, A *string }
 				}{
-					S: struct{ S, A string }{
-						S: "string1",
+					S: struct{ S, A *string }{
+						S: StringPtr("string1"),
 					},
 				},
 				&struct {
-					S struct{ S, B string }
+					S struct{ S, B *string }
 				}{
-					S: struct{ S, B string }{
-						S: "string2",
-						B: "string3",
+					S: struct{ S, B *string }{
+						S: StringPtr("string2"),
+						B: StringPtr("string3"),
 					},
 				},
 			},
 		},
 
-		// Errors
+		//// Errors
 
 		{
 			// Non-pointer in1

--- a/unpack.go
+++ b/unpack.go
@@ -158,7 +158,7 @@ func unpackStructValue(namePrefix string, structValue reflect.Value,
 		// TODO(ccross): we don't validate types inside nil struct pointers
 		// Move type validation to a function that runs on each factory once
 		switch kind := fieldValue.Kind(); kind {
-		case reflect.Bool, reflect.String, reflect.Struct:
+		case reflect.Struct:
 			// Do nothing
 		case reflect.Slice:
 			elemType := field.Type.Elem()
@@ -192,9 +192,9 @@ func unpackStructValue(namePrefix string, structValue reflect.Value,
 				panic(fmt.Errorf("field %s contains a pointer to %s", propertyName, ptrKind))
 			}
 
-		case reflect.Int, reflect.Uint:
+		case reflect.Bool, reflect.String, reflect.Int, reflect.Uint:
 			if !proptools.HasTag(field, "blueprint", "mutated") {
-				panic(fmt.Errorf(`int field %s must be tagged blueprint:"mutated"`, propertyName))
+				panic(fmt.Errorf(`field %s must be tagged blueprint:"mutated"`, propertyName))
 			}
 
 		default:

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -59,9 +59,9 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				Name string
+				Name *string
 			}{
-				Name: "abc",
+				Name: StringPtr("abc"),
 			},
 		},
 	},
@@ -74,9 +74,9 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				IsGood bool
+				IsGood *bool
 			}{
-				IsGood: true,
+				IsGood: BoolPtr(true),
 			},
 		},
 	},
@@ -133,11 +133,11 @@ var validUnpackTestCases = []struct {
 		output: []interface{}{
 			struct {
 				Nested struct {
-					Name string
+					Name *string
 				}
 			}{
-				Nested: struct{ Name string }{
-					Name: "abc",
+				Nested: struct{ Name *string }{
+					Name: StringPtr("abc"),
 				},
 			},
 		},
@@ -155,8 +155,8 @@ var validUnpackTestCases = []struct {
 			struct {
 				Nested interface{}
 			}{
-				Nested: &struct{ Name string }{
-					Name: "def",
+				Nested: &struct{ Name *string }{
+					Name: StringPtr("def"),
 				},
 			},
 		},
@@ -175,15 +175,15 @@ var validUnpackTestCases = []struct {
 		output: []interface{}{
 			struct {
 				Nested struct {
-					Foo string
+					Foo *string
 				}
-				Bar bool
+				Bar *bool
 				Baz []string
 			}{
-				Nested: struct{ Foo string }{
-					Foo: "abc",
+				Nested: struct{ Foo *string }{
+					Foo: StringPtr("abc"),
 				},
-				Bar: false,
+				Bar: BoolPtr(false),
 				Baz: []string{"def", "ghi"},
 			},
 		},
@@ -202,17 +202,17 @@ var validUnpackTestCases = []struct {
 		output: []interface{}{
 			struct {
 				Nested struct {
-					Foo string `allowNested:"true"`
+					Foo *string `allowNested:"true"`
 				} `blueprint:"filter(allowNested:\"true\")"`
-				Bar bool
+				Bar *bool
 				Baz []string
 			}{
 				Nested: struct {
-					Foo string `allowNested:"true"`
+					Foo *string `allowNested:"true"`
 				}{
-					Foo: "abc",
+					Foo: StringPtr("abc"),
 				},
-				Bar: false,
+				Bar: BoolPtr(false),
 				Baz: []string{"def", "ghi"},
 			},
 		},
@@ -231,15 +231,15 @@ var validUnpackTestCases = []struct {
 		output: []interface{}{
 			struct {
 				Nested struct {
-					Foo string
+					Foo *string
 				} `blueprint:"filter(allowNested:\"true\")"`
-				Bar bool
+				Bar *bool
 				Baz []string
 			}{
-				Nested: struct{ Foo string }{
-					Foo: "",
+				Nested: struct{ Foo *string }{
+					Foo: nil,
 				},
-				Bar: false,
+				Bar: BoolPtr(false),
 				Baz: []string{"def", "ghi"},
 			},
 		},
@@ -269,13 +269,13 @@ var validUnpackTestCases = []struct {
 				}
 			}{
 				EmbeddedStruct: EmbeddedStruct{
-					Name: "abc",
+					Name: StringPtr("abc"),
 				},
 				Nested: struct {
 					EmbeddedStruct
 				}{
 					EmbeddedStruct: EmbeddedStruct{
-						Name: "def",
+						Name: StringPtr("def"),
 					},
 				},
 			},
@@ -299,14 +299,14 @@ var validUnpackTestCases = []struct {
 					EmbeddedInterface
 				}
 			}{
-				EmbeddedInterface: &struct{ Name string }{
-					Name: "abc",
+				EmbeddedInterface: &struct{ Name *string }{
+					Name: StringPtr("abc"),
 				},
 				Nested: struct {
 					EmbeddedInterface
 				}{
-					EmbeddedInterface: &struct{ Name string }{
-						Name: "def",
+					EmbeddedInterface: &struct{ Name *string }{
+						Name: StringPtr("def"),
 					},
 				},
 			},
@@ -325,24 +325,24 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				Name string
+				Name *string
 				EmbeddedStruct
 				Nested struct {
-					Name string
+					Name *string
 					EmbeddedStruct
 				}
 			}{
-				Name: "abc",
+				Name: StringPtr("abc"),
 				EmbeddedStruct: EmbeddedStruct{
-					Name: "abc",
+					Name: StringPtr("abc"),
 				},
 				Nested: struct {
-					Name string
+					Name *string
 					EmbeddedStruct
 				}{
-					Name: "def",
+					Name: StringPtr("def"),
 					EmbeddedStruct: EmbeddedStruct{
-						Name: "def",
+						Name: StringPtr("def"),
 					},
 				},
 			},
@@ -361,24 +361,24 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				Name string
+				Name *string
 				EmbeddedInterface
 				Nested struct {
-					Name string
+					Name *string
 					EmbeddedInterface
 				}
 			}{
-				Name: "abc",
-				EmbeddedInterface: &struct{ Name string }{
-					Name: "abc",
+				Name: StringPtr("abc"),
+				EmbeddedInterface: &struct{ Name *string }{
+					Name: StringPtr("abc"),
 				},
 				Nested: struct {
-					Name string
+					Name *string
 					EmbeddedInterface
 				}{
-					Name: "def",
-					EmbeddedInterface: &struct{ Name string }{
-						Name: "def",
+					Name: StringPtr("def"),
+					EmbeddedInterface: &struct{ Name *string }{
+						Name: StringPtr("def"),
 					},
 				},
 			},
@@ -399,11 +399,11 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				Name  string
+				Name  *string
 				List  []string
 				List2 []string
 			}{
-				Name:  "def",
+				Name:  StringPtr("def"),
 				List:  []string{"abc"},
 				List2: []string{"def"},
 			},
@@ -422,20 +422,20 @@ var validUnpackTestCases = []struct {
 		output: []interface{}{
 			struct {
 				Nested struct {
-					Name string
+					Name *string
 				}
 			}{
-				Nested: struct{ Name string }{
-					Name: "abc",
+				Nested: struct{ Name *string }{
+					Name: StringPtr("abc"),
 				},
 			},
 			struct {
 				Nested struct {
-					Name string
+					Name *string
 				}
 			}{
-				Nested: struct{ Name string }{
-					Name: "abc",
+				Nested: struct{ Name *string }{
+					Name: StringPtr("abc"),
 				},
 			},
 			struct {
@@ -455,18 +455,18 @@ var validUnpackTestCases = []struct {
 		output: []interface{}{
 			struct {
 				Nested *struct {
-					Name string
+					Name *string
 				}
 			}{
-				Nested: &struct{ Name string }{
-					Name: "abc",
+				Nested: &struct{ Name *string }{
+					Name: StringPtr("abc"),
 				},
 			},
 		},
 		empty: []interface{}{
 			&struct {
 				Nested *struct {
-					Name string
+					Name *string
 				}
 			}{},
 		},
@@ -486,7 +486,7 @@ var validUnpackTestCases = []struct {
 				Nested interface{}
 			}{
 				Nested: &EmbeddedStruct{
-					Name: "abc",
+					Name: StringPtr("abc"),
 				},
 			},
 		},
@@ -512,30 +512,30 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				String     string
+				String     *string
 				String_ptr *string
-				Bool       bool
+				Bool       *bool
 				Bool_ptr   *bool
 				List       []string
 			}{
-				String:     "012abc",
+				String:     StringPtr("abc"),
 				String_ptr: proptools.StringPtr("abc"),
-				Bool:       true,
+				Bool:       BoolPtr(false),
 				Bool_ptr:   proptools.BoolPtr(false),
 				List:       []string{"0", "1", "2", "a", "b", "c"},
 			},
 		},
 		empty: []interface{}{
 			&struct {
-				String     string
+				String     *string
 				String_ptr *string
-				Bool       bool
+				Bool       *bool
 				Bool_ptr   *bool
 				List       []string
 			}{
-				String:     "012",
+				String:     StringPtr("012"),
 				String_ptr: proptools.StringPtr("012"),
-				Bool:       true,
+				Bool:       BoolPtr(true),
 				Bool_ptr:   proptools.BoolPtr(true),
 				List:       []string{"0", "1", "2"},
 			},
@@ -543,7 +543,7 @@ var validUnpackTestCases = []struct {
 	},
 }
 
-type EmbeddedStruct struct{ Name string }
+type EmbeddedStruct struct{ Name *string }
 type EmbeddedInterface interface{}
 
 func TestUnpackProperties(t *testing.T) {


### PR DESCRIPTION
We only allow user to define string & bool properties with `blueprint:"mutated"` tag.