### PR TITLE
Store build.ninja deps in .ninja_deps

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -113,6 +113,7 @@ var (
 			Command:     "$builder $extra -b $buildDir -n $ninjaBuildDir -d $out.d -o $out $in",
 			CommandDeps: []string{"$builder"},
 			Description: "$builder $out",
+			Deps:        blueprint.DepsGCC,
 			Depfile:     "$out.d",
 			Restat:      true,
 		},

--- a/bootstrap/build.ninja
+++ b/bootstrap/build.ninja
@@ -9,6 +9,7 @@ ninja_required_version = 1.7.0
 
 rule build.ninja
     command = ${builder} ${extraArgs} -b ${bootstrapBuildDir} -n ${builddir} -d ${out}.d -o ${out} ${in}
+    deps = gcc
     depfile = ${out}.d
     description = ${builder} ${out}
 


### PR DESCRIPTION
We're already going to load the .ninja_deps file, so we may as well use it. These are the only two files in our build that don't.

Test: dump the .ninja_deps file, see the dependencies