### PR TITLE
Support go1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-    - 1.8.3
     - 1.9
+    - "1.10"
 
 cache:
     directories:

--- a/context.go
+++ b/context.go
@@ -1097,7 +1097,7 @@ func getLocalStringListFromScope(scope *parser.Scope, v string) ([]string, scann
 				Pos: assignment.EqualsPos,
 			}
 		default:
-			panic(fmt.Errorf("unknown value type: %d", assignment.Value.Type))
+			panic(fmt.Errorf("unknown value type: %d", assignment.Value.Type()))
 		}
 	}
 }
@@ -1115,7 +1115,7 @@ func getStringFromScope(scope *parser.Scope, v string) (string, scanner.Position
 				Pos: assignment.EqualsPos,
 			}
 		default:
-			panic(fmt.Errorf("unknown value type: %d", assignment.Value.Type))
+			panic(fmt.Errorf("unknown value type: %d", assignment.Value.Type()))
 		}
 	}
 }

--- a/gotestmain/gotestmain.go
+++ b/gotestmain/gotestmain.go
@@ -160,6 +160,14 @@ func (matchString) ImportPath() string {
 	return "{{.Package}}"
 }
 
+func (matchString) StartTestLog(io.Writer) {
+	panic("shouldn't get here")
+}
+
+func (matchString) StopTestLog() error {
+	panic("shouldn't get here")
+}
+
 func main() {
 {{if .MainStartTakesInterface}}
 	m := testing.MainStart(matchString{}, t, nil, nil)


### PR DESCRIPTION
Add stubs for the new testDeps interface functions. Also removes testing for 1.8.