### PR TITLE
Try to make GOROOT relative in Go 1.10

### DIFF
--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -15,7 +15,10 @@
 package bootstrap
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/google/blueprint"
 )
@@ -39,7 +42,16 @@ var (
 		return NinjaBuildDir
 	})
 	goRoot = bootstrapVariable("goRoot", func() string {
-		return runtime.GOROOT()
+		goroot := runtime.GOROOT()
+		// Prefer to omit absolute paths from the ninja file
+		if cwd, err := os.Getwd(); err == nil {
+			if relpath, err := filepath.Rel(cwd, goroot); err == nil {
+				if !strings.HasPrefix(relpath, "../") {
+					goroot = relpath
+				}
+			}
+		}
+		return goroot
 	})
 	compileCmd = bootstrapVariable("compileCmd", func() string {
 		return "$goRoot/pkg/tool/" + runtime.GOOS + "_" + runtime.GOARCH + "/compile"


### PR DESCRIPTION
In Go 1.10, runtime.GOROOT() will attempt to find the current location of the go binaries, instead of using the GOROOT_FINAL that was baked into the binaries. This means that GOROOT() will usually return an absolute path.

We avoid putting absolute paths into the ninja file, since any change to the paths would then cause all of the actions including it to rebuild. Since we've got a decent number of build tools in Android using Go now, this causes us to rebuild a decent portion of the tree.

Instead of passing the GOROOT around manually in a side channel, just let the Go 1.10 detection do its thing, and always try to turn the result into a relative path.