### PR TITLE
Return an error when renaming a module that doesn't exist

### DIFF
--- a/name_interface.go
+++ b/name_interface.go
@@ -126,20 +126,22 @@ func (s *SimpleNameInterface) ModuleFromName(moduleName string, namespace Namesp
 func (s *SimpleNameInterface) Rename(oldName string, newName string, namespace Namespace) (errs []error) {
 	existingGroup, exists := s.modules[newName]
 	if exists {
-		errs = append(errs,
+		return []error{
 			// seven characters at the start of the second line to align with the string "error: "
 			fmt.Errorf("renaming module %q to %q conflicts with existing module\n"+
 				"       %s <-- existing module defined here",
 				oldName, newName, existingGroup.modules[0].pos),
-		)
-		return errs
+		}
 	}
 
-	group := s.modules[oldName]
+	group, exists := s.modules[oldName]
+	if !exists {
+		return []error{fmt.Errorf("module %q to renamed to %q doesn't exist", oldName, newName)}
+	}
 	s.modules[newName] = group
 	delete(s.modules, group.name)
 	group.name = newName
-	return []error{}
+	return nil
 }
 
 func (s *SimpleNameInterface) AllModules() []ModuleGroup {


### PR DESCRIPTION
Misusing Rename was causing a nil pointer derefernece, return
an error if group was not found in s.modules.

Bug: 77922456
Change-Id: I7e7b20b1595d569ae07c755bd29d701e0e5dab78