### PR TITLE
Improve indentation for multi-line expressions

### DIFF
--- a/parser/printer.go
+++ b/parser/printer.go
@@ -173,15 +173,34 @@ func (p *printer) printMap(m *Map) {
 }
 
 func (p *printer) printOperator(operator *Operator) {
+	p.printOperatorInternal(operator, true)
+}
+
+func (p *printer) printOperatorInternal(operator *Operator, allowIndent bool) {
 	p.printExpression(operator.Args[0])
 	p.requestSpace()
 	p.printToken(string(operator.Operator), operator.OperatorPos)
+
+	indented := false
 	if operator.Args[0].End().Line == operator.Args[1].Pos().Line {
 		p.requestSpace()
 	} else {
+		if allowIndent {
+			indented = true
+			p.indent(p.curIndent() + 4)
+		}
 		p.requestNewline()
 	}
-	p.printExpression(operator.Args[1])
+
+	if op, isOp := operator.Args[1].(*Operator); isOp {
+		p.printOperatorInternal(op, false)
+	} else {
+		p.printExpression(operator.Args[1])
+	}
+
+	if indented {
+		p.unindent(p.pos)
+	}
 }
 
 func (p *printer) printProperty(property *Property) {

--- a/parser/printer_test.go
+++ b/parser/printer_test.go
@@ -166,6 +166,22 @@ bar {
 	},
 	{
 		input: `
+foo {
+    bar: "b" +
+        "a" +
+	"z",
+}
+`,
+		output: `
+foo {
+    bar: "b" +
+        "a" +
+        "z",
+}
+`,
+	},
+	{
+		input: `
 foo = "stuff"
 bar = foo
 baz = foo + bar
@@ -190,6 +206,18 @@ foo = 100
 bar = foo
 baz = foo + bar
 baz += foo
+`,
+	},
+	{
+		input: `
+foo = "bar " +
+    "" +
+    "baz"
+`,
+		output: `
+foo = "bar " +
+    "" +
+    "baz"
 `,
 	},
 	{


### PR DESCRIPTION
When someone used a multiline string:

```
    cmd: "..." +
         "...",
```

bpfmt used to print this out as:

```
    cmd: "..." +
    "...",
```

This change doesn't do the quote alignment like I see in some of our
user-created instances of this, but it does indent a single level:

```
    cmd: "..." +
        "...",
```

Test: unit tests
Test: Compared bpfmt results before and after across AOSP