### PR TITLE
Allow multiple dependencies on the same module

### DIFF
--- a/visit_test.go
+++ b/visit_test.go
@@ -83,6 +83,9 @@ func visitMutator(ctx TopDownMutatorContext) {
 //   D
 //   |
 //   E
+//  / \
+//  \ /
+//   F
 func setupVisitTest(t *testing.T) *Context {
 	ctx := NewContext()
 	ctx.RegisterModuleType("visit_module", newVisitModule)
@@ -113,6 +116,11 @@ func setupVisitTest(t *testing.T) *Context {
 	
 			visit_module {
 				name: "E",
+				visit: ["F", "F"],
+			}
+
+			visit_module {
+				name: "F",
 			}
 		`),
 	})
@@ -142,10 +150,16 @@ func TestVisit(t *testing.T) {
 	ctx := setupVisitTest(t)
 
 	topModule := ctx.modulesFromName("A", nil)[0].logicModule.(*visitModule)
-	assertString(t, topModule.properties.VisitDepsDepthFirst, "EDCB")
-	assertString(t, topModule.properties.VisitDepsDepthFirstIf, "EDC")
+	assertString(t, topModule.properties.VisitDepsDepthFirst, "FEDCB")
+	assertString(t, topModule.properties.VisitDepsDepthFirstIf, "FEDC")
 	assertString(t, topModule.properties.VisitDirectDeps, "B")
 	assertString(t, topModule.properties.VisitDirectDepsIf, "")
+
+	eModule := ctx.modulesFromName("E", nil)[0].logicModule.(*visitModule)
+	assertString(t, eModule.properties.VisitDepsDepthFirst, "F")
+	assertString(t, eModule.properties.VisitDepsDepthFirstIf, "F")
+	assertString(t, eModule.properties.VisitDirectDeps, "FF")
+	assertString(t, eModule.properties.VisitDirectDepsIf, "FF")
 }
 
 func assertString(t *testing.T, got, expected string) {


### PR DESCRIPTION
Allow adding multiple dependencies on the same module.  Adds a flag
to Context.walkDeps to determine whether dependencies should be
visited multiple times, and clarifies the behavior of
VisitDepsDepthFirst (continues to visit each module once, even if
there are multiple dependencies on it) and VisitDirectDeps (may
visit a module multiple times).

Test: TestWalkDepsDuplicates, TestVisit
Change-Id: I58afbe90490aca102d242d63e185386e1fe55d73