### PR TITLE
Emit errors on mixed property syntax

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -302,8 +302,10 @@ func (p *parser) parseProperty(isModule, compat bool) (property *Property) {
 	pos := p.scanner.Position
 
 	if isModule {
-		if compat && p.tok == ':' {
-			p.accept(':')
+		if compat {
+			if !p.accept(':') {
+				return
+			}
 		} else {
 			if !p.accept('=') {
 				return

--- a/parser/printer_test.go
+++ b/parser/printer_test.go
@@ -33,7 +33,7 @@ foo {}
 	},
 	{
 		input: `
-foo{name= "abc",num= 4,}
+foo(name= "abc",num= 4,)
 `,
 		output: `
 foo {


### PR DESCRIPTION
This commit refines `compat` condition in `parseProperty()` so that a
module definition would either use the new syntax or the old syntax,
but not something in the between, such as

    cc_library {
        name: "bad_example",
        srcs= ["bad.c"],
    }

Test: lunch aosp_arm64-userdebug; make  # runs unit test
Change-Id: If2d3e5d55edccc28d314d99b83b0f54e5c53ac35