### PR TITLE
Add go1.11 go.mod and fix `go vet` issues

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -358,7 +358,7 @@ type goBinary struct {
 			TestSrcs []string
 		}
 
-		Tool_dir bool `blueprint:mutated`
+		Tool_dir bool `blueprint:"mutated"`
 	}
 
 	installPath string

--- a/context.go
+++ b/context.go
@@ -719,7 +719,6 @@ func (c *Context) WalkBlueprintsFiles(rootDir string, filePaths []string,
 	descendantsMap, err := findBlueprintDescendants(filePaths)
 	if err != nil {
 		panic(err.Error())
-		return nil, []error{err}
 	}
 	blueprintsSet := make(map[string]bool)
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/blueprint


### PR DESCRIPTION
go1.11 adds module support, so that modules & packages can be used outside of $GOPATH. So add the file declaring this the module for github.com/google/blueprint, and fix some issues found by `go vet`.