### PR TITLE
Fix globs matching files with wildcard characters in the name

### DIFF
--- a/pathtools/glob.go
+++ b/pathtools/glob.go
@@ -137,7 +137,7 @@ func glob(fs FileSystem, pattern string, hasRecursive bool) (matches, dirs []str
 				matches = append(matches, recurseDirs...)
 			} else {
 				dirs = append(dirs, m)
-				newMatches, err := fs.glob(filepath.Join(m, file))
+				newMatches, err := fs.glob(filepath.Join(MatchEscape(m), file))
 				if err != nil {
 					return nil, nil, err
 				}
@@ -425,4 +425,16 @@ func WriteFileIfChanged(filename string, data []byte, perm os.FileMode) error {
 	}
 
 	return nil
+}
+
+var matchEscaper = strings.NewReplacer(
+	`*`, `\*`,
+	`?`, `\?`,
+	`[`, `\[`,
+	`]`, `\]`,
+)
+
+// MatchEscape returns its inputs with characters that would be interpreted by
+func MatchEscape(s string) string {
+	return matchEscaper.Replace(s)
 }


### PR DESCRIPTION
Globs that match a file that looks like a glob were causing duplicate
results because the prefix match would then re-match the
filename as a wildcard.  Add escaping to prevent re-matching.

Also add tests for globs on files with wildcards, tests for
? and [a-z] glob matches supported by filepath.Match, and tests
for escaped wildcard characters.

Test: glob_test.go
Change-Id: Id11a754863979bb36cca0dbd18ea2e76dd1470e3