### PR TITLE
Allow mutated property structs to contain slices of non-strings

### DIFF
--- a/proptools/clone.go
+++ b/proptools/clone.go
@@ -52,9 +52,6 @@ func CopyProperties(dstValue, srcValue reflect.Value) {
 			CopyProperties(dstFieldValue, srcFieldValue)
 		case reflect.Slice:
 			if !srcFieldValue.IsNil() {
-				if field.Type.Elem().Kind() != reflect.String {
-					panic(fmt.Errorf("can't copy field %q: slice elements are not strings", field.Name))
-				}
 				if srcFieldValue != dstFieldValue {
 					newSlice := reflect.MakeSlice(field.Type, srcFieldValue.Len(),
 						srcFieldValue.Len())

--- a/proptools/clone_test.go
+++ b/proptools/clone_test.go
@@ -71,6 +71,19 @@ var clonePropertiesTestCases = []struct {
 		out: &struct{ S []string }{},
 	},
 	{
+		// Clone slice of structs
+		in: &struct{ S []struct{ T string } }{
+			S: []struct{ T string }{
+				{"string1"}, {"string2"},
+			},
+		},
+		out: &struct{ S []struct{ T string } }{
+			S: []struct{ T string }{
+				{"string1"}, {"string2"},
+			},
+		},
+	},
+	{
 		// Clone pointer to bool
 		in: &struct{ B1, B2 *bool }{
 			B1: BoolPtr(true),
@@ -315,6 +328,17 @@ var cloneEmptyPropertiesTestCases = []struct {
 		// Clone nil slice
 		in:  &struct{ S []string }{},
 		out: &struct{ S []string }{},
+	},
+	{
+		// Clone slice of structs
+		in: &struct{ S []struct{ T string } }{
+			S: []struct{ T string }{
+				{"string1"}, {"string2"},
+			},
+		},
+		out: &struct{ S []struct{ T string } }{
+			S: []struct{ T string }(nil),
+		},
 	},
 	{
 		// Clone pointer to bool

--- a/unpack.go
+++ b/unpack.go
@@ -163,7 +163,9 @@ func unpackStructValue(namePrefix string, structValue reflect.Value,
 		case reflect.Slice:
 			elemType := field.Type.Elem()
 			if elemType.Kind() != reflect.String {
-				panic(fmt.Errorf("field %s is a non-string slice", propertyName))
+				if !proptools.HasTag(field, "blueprint", "mutated") {
+					panic(fmt.Errorf("field %s is a non-string slice", propertyName))
+				}
 			}
 		case reflect.Interface:
 			if fieldValue.IsNil() {

--- a/unpack_test.go
+++ b/unpack_test.go
@@ -111,13 +111,15 @@ var validUnpackTestCases = []struct {
 		`,
 		output: []interface{}{
 			struct {
-				Stuff []string
-				Empty []string
-				Nil   []string
+				Stuff     []string
+				Empty     []string
+				Nil       []string
+				NonString []struct{ S string } `blueprint:"mutated"`
 			}{
-				Stuff: []string{"asdf", "jkl;", "qwert", "uiop", "bnm,"},
-				Empty: []string{},
-				Nil:   nil,
+				Stuff:     []string{"asdf", "jkl;", "qwert", "uiop", "bnm,"},
+				Empty:     []string{},
+				Nil:       nil,
+				NonString: nil,
 			},
 		},
 	},


### PR DESCRIPTION
Property structs can now contain slices of structs and other
non-strings as long as they are tagged with `blueprint:"mutated"`.

Test: clone_test.go
Test: unpack_test.go
Change-Id: Ib77348dc6e7314a24f17caba10040f7d3ac54e54