### PR TITLE
Make sure all modules have a name.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1297,8 +1297,8 @@ func (c *Context) addModule(module *moduleInfo) []error {
 			&BlueprintError{
 				Err: fmt.Errorf("property 'name' is missing from a module"),
 				Pos: module.pos,
-	    },
-	  }
+			},
+		}
 	}
 	c.moduleInfo[module.logicModule] = module
 

--- a/context.go
+++ b/context.go
@@ -1292,6 +1292,14 @@ func (c *Context) processModuleDef(moduleDef *parser.Module,
 
 func (c *Context) addModule(module *moduleInfo) []error {
 	name := module.logicModule.Name()
+	if name == "" {
+		return []error{
+			&BlueprintError{
+				Err: fmt.Errorf("property 'name' is missing from a module"),
+				Pos: module.pos,
+	    },
+	  }
+	}
 	c.moduleInfo[module.logicModule] = module
 
 	group := &moduleGroup{

--- a/context_test.go
+++ b/context_test.go
@@ -482,3 +482,29 @@ func TestWalkingWithSyntaxError(t *testing.T) {
 	}
 
 }
+
+func TestParseFailsForModuleWithoutName(t *testing.T) {
+	ctx := NewContext()
+	ctx.MockFileSystem(map[string][]byte{
+		"Blueprints": []byte(`
+			foo_module {
+			    name: "A",
+			}
+			
+			bar_module {
+			    deps: ["A"],
+			}
+		`),
+	})
+	ctx.RegisterModuleType("foo_module", newFooModule)
+	ctx.RegisterModuleType("bar_module", newBarModule)
+
+	_, errs := ctx.ParseBlueprintsFiles("Blueprints")
+
+	expectedErrs := []error{
+		errors.New(`Blueprints:6:4: property 'name' is missing from a module`),
+	}
+	if fmt.Sprintf("%s", expectedErrs) != fmt.Sprintf("%s", errs) {
+		t.Errorf("Incorrect errors; expected:\n%s\ngot:\n%s", expectedErrs, errs)
+	}
+}


### PR DESCRIPTION
Throw an error if run into a module without a name when generating
contexts.

Test: context_test.go
Change-Id: I3976d86d1f15b8ac10a7a38aa42ae277740a8f3b