### PR TITLE
Add link dependency on test package archive

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -561,7 +561,7 @@ func buildGoTest(ctx blueprint.ModuleContext, testRoot, testPkgArchive,
 		Optional: true,
 	})
 
-	var linkDeps []string
+	linkDeps := []string{testPkgArchive}
 	libDirFlags := []string{"-L " + testRoot}
 	testDeps := []string{}
 	ctx.VisitDepsDepthFirstIf(isGoPackageProducer,


### PR DESCRIPTION
The test package archive was being picked up through "-L" + testRoot,
but did not have a dependency on it.  If the *_test.go file was
changed but not the implementation then the tests would not be
rerun.

Test: Add t.Fatal() to a *_test.go file and rebuild.
Change-Id: I32b8c7a0fa1d5b76b1242646887fe937e396e318