### PR TITLE
Add --empty-ninja-file for test usecases

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -93,6 +93,11 @@ done
 # If RUN_TESTS is set, behave like -t was passed in as an option.
 [ ! -z "$RUN_TESTS" ] && EXTRA_ARGS="${EXTRA_ARGS} -t"
 
+# If EMPTY_NINJA_FILE is set, have the primary build write out a 0-byte ninja
+# file instead of a full length one. Useful if you don't plan on executing the
+# build, but want to verify the primary builder execution.
+[ ! -z "$EMPTY_NINJA_FILE" ] && EXTRA_ARGS="${EXTRA_ARGS} --empty-ninja-file"
+
 # Allow the caller to pass in a list of module files
 if [ -z "${BLUEPRINT_LIST_FILE}" ]; then
   BLUEPRINT_LIST_FILE="${BUILDDIR}/.bootstrap/bplist"

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -650,6 +650,9 @@ func (s *singleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 	if s.config.moduleListFile != "" {
 		extraSharedFlagArray = append(extraSharedFlagArray, "-l", s.config.moduleListFile)
 	}
+	if s.config.emptyNinjaFile {
+		extraSharedFlagArray = append(extraSharedFlagArray, "--empty-ninja-file")
+	}
 	extraSharedFlagString := strings.Join(extraSharedFlagArray, " ")
 
 	var primaryBuilderName, primaryBuilderExtraFlags string

--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -41,6 +41,7 @@ var (
 	runGoTests     bool
 	noGC           bool
 	moduleListFile string
+	emptyNinjaFile bool
 
 	BuildDir      string
 	NinjaBuildDir string
@@ -60,6 +61,7 @@ func init() {
 	flag.BoolVar(&noGC, "nogc", false, "turn off GC for debugging")
 	flag.BoolVar(&runGoTests, "t", false, "build and run go tests during bootstrap")
 	flag.StringVar(&moduleListFile, "l", "", "file that lists filepaths to parse")
+	flag.BoolVar(&emptyNinjaFile, "empty-ninja-file", false, "write out a 0-byte ninja file")
 }
 
 func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...string) {
@@ -122,7 +124,9 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 
 	bootstrapConfig := &Config{
 		stage: stage,
+
 		topLevelBlueprintsFile: flag.Arg(0),
+		emptyNinjaFile:         emptyNinjaFile,
 		runGoTests:             runGoTests,
 		moduleListFile:         moduleListFile,
 	}
@@ -173,6 +177,10 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	err = ctx.WriteBuildFile(buf)
 	if err != nil {
 		fatalf("error generating Ninja file contents: %s", err)
+	}
+
+	if stage == StageMain && emptyNinjaFile {
+		buf.Reset()
 	}
 
 	const outFilePermissions = 0666

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -105,6 +105,7 @@ type Config struct {
 
 	topLevelBlueprintsFile string
 
+	emptyNinjaFile bool
 	runGoTests     bool
 	moduleListFile string
 }


### PR DESCRIPTION
In cases that we want to run blueprint-based builds in many configurations to verify all of the logic works without errors, but don't care about running the final ninja file, writing it out only wastes time and disk space. So add a --empty-ninja-file option that writes out an empty ninja file instead.

Our specific use case (Soong's build_test / multiproduct_kati) runs Soong several hundred times for different configurations, and the ninja files are around 1GB, which leads to several hundred gigabytes of disk writes (and persistent use during incremental generation).