### PR TITLE
bpmodify: add argument if it is missing

### DIFF
--- a/bpmodify/bpmodify.go
+++ b/bpmodify/bpmodify.go
@@ -148,7 +148,14 @@ func processModule(module *parser.Module, moduleName string,
 		}
 	}
 
-	return false, nil
+	prop := parser.Property{Name: *parameter, Value: &parser.List{}}
+	modified, errs = processParameter(prop.Value, *parameter, moduleName, file)
+
+	if modified {
+		module.Properties = append(module.Properties, &prop)
+	}
+
+	return modified, errs
 }
 
 func processParameter(value parser.Expression, paramName, moduleName string,


### PR DESCRIPTION
before, adding to a list which had no entries would do nothing (and not
throw any errors). Now it will create the list and add a single element
as expected.

Change-Id: I8c48a42303f7d9b3741868ad86097e2071ec434a