### PR TITLE
Support go 1.12 initialization functions

### DIFF
--- a/package_ctx.go
+++ b/package_ctx.go
@@ -137,7 +137,7 @@ func checkCalledFromInit() {
 			panic("not called from an init func")
 		}
 
-		if funcName == "init" || strings.HasPrefix(funcName, "init·") {
+		if funcName == "init" || strings.HasSuffix("init.ializers") || strings.HasPrefix(funcName, "init·") {
 			return
 		}
 	}


### PR DESCRIPTION
As listed in https://tip.golang.org/doc/go1.12#runtime

```
 Tracebacks, runtime.Caller, and runtime.Callers no longer include
 compiler-generated initialization functions. Doing a traceback during
 the initialization of a global variable will now show a function named
 PKG.init.ializers.
```

Test: run the soong tests with go 1.12 pre-release