### PR TITLE
Allow Context to query Singletons

### DIFF
--- a/context.go
+++ b/context.go
@@ -2347,6 +2347,7 @@ func (c *Context) generateSingletonBuildActions(config interface{},
 		scope := newLocalScope(nil, singletonNamespacePrefix(info.name))
 
 		sctx := &singletonContext{
+			name:    info.name,
 			context: c,
 			config:  config,
 			scope:   scope,
@@ -2975,6 +2976,25 @@ func (c *Context) VisitAllModuleVariants(module Module,
 	visit func(Module)) {
 
 	c.visitAllModuleVariants(c.moduleInfo[module], visit)
+}
+
+// Singletons returns a list of all registered Singletons.
+func (c *Context) Singletons() []Singleton {
+	var ret []Singleton
+	for _, s := range c.singletonInfo {
+		ret = append(ret, s.singleton)
+	}
+	return ret
+}
+
+// SingletonName returns the name that the given singleton was registered with.
+func (c *Context) SingletonName(singleton Singleton) string {
+	for _, s := range c.singletonInfo {
+		if s.singleton == singleton {
+			return s.name
+		}
+	}
+	return ""
 }
 
 // WriteBuildFile writes the Ninja manifeset text for the generated build

--- a/singleton_ctx.go
+++ b/singleton_ctx.go
@@ -27,6 +27,8 @@ type Singleton interface {
 type SingletonContext interface {
 	Config() interface{}
 
+	Name() string
+
 	ModuleName(module Module) string
 	ModuleDir(module Module) string
 	ModuleSubDir(module Module) string
@@ -83,6 +85,7 @@ type SingletonContext interface {
 var _ SingletonContext = (*singletonContext)(nil)
 
 type singletonContext struct {
+	name    string
 	context *Context
 	config  interface{}
 	scope   *localScope
@@ -96,6 +99,10 @@ type singletonContext struct {
 
 func (s *singletonContext) Config() interface{} {
 	return s.config
+}
+
+func (s *singletonContext) Name() string {
+	return s.name
 }
 
 func (s *singletonContext) ModuleName(logicModule Module) string {


### PR DESCRIPTION
Add Context.Singletons and Context.SingletonName to allow primary
builders to query Singletons returned by all registered
SingletonFactories.

Change-Id: Iee85643dd47f7472e6bb5ae8004374bd6ea0419e