### PR TITLE
Panic when copying private properties.

### DIFF
--- a/proptools/clone.go
+++ b/proptools/clone.go
@@ -35,8 +35,7 @@ func CopyProperties(dstValue, srcValue reflect.Value) {
 
 	for i, field := range typeFields(typ) {
 		if field.PkgPath != "" {
-			// The field is not exported so just skip it.
-			continue
+			panic(fmt.Errorf("can't copy a private field %q", field.Name))
 		}
 
 		srcFieldValue := srcValue.Field(i)


### PR DESCRIPTION
When CopyProperties comes across private properties, it silently ignores
them. This is error-prone and can result in a bug very hard to debug if
the developer is unaware of the behavior.

Change-Id: Id6a0752e384ec7fed35728c1e87dbfa95fea84f2