### PR TITLE
bpdoc preformatted text improvments

### DIFF
--- a/bootstrap/bpdoc/bpdoc.go
+++ b/bootstrap/bpdoc/bpdoc.go
@@ -36,7 +36,7 @@ type ModuleType struct {
 	PkgPath string
 
 	// Text is the contents of the comment documenting the module type.
-	Text string
+	Text template.HTML
 
 	// PropertyStructs is a list of PropertyStruct objects that contain information about each
 	// property struct that is used by the module type, containing all properties that are valid

--- a/bootstrap/bpdoc/properties.go
+++ b/bootstrap/bpdoc/properties.go
@@ -224,30 +224,11 @@ func structProperties(structType *ast.StructType) (props []Property, err error) 
 				typ = fmt.Sprintf("%T", f.Type)
 			}
 
-			var html template.HTML
-
-			lines := strings.Split(text, "\n")
-			preformatted := false
-			for _, line := range lines {
-				r, _ := utf8.DecodeRuneInString(line)
-				indent := unicode.IsSpace(r)
-				if indent && !preformatted {
-					html += "<pre>\n"
-				} else if !indent && preformatted {
-					html += "</pre>\n"
-				}
-				preformatted = indent
-				html += template.HTML(template.HTMLEscapeString(line)) + "\n"
-			}
-			if preformatted {
-				html += "</pre>\n"
-			}
-
 			props = append(props, Property{
 				Name:       name,
 				Type:       typ,
 				Tag:        reflect.StructTag(tag),
-				Text:       html,
+				Text:       formatText(text),
 				Properties: innerProps,
 			})
 		}
@@ -278,4 +259,26 @@ func filterPropsByTag(props *[]Property, key, value string, exclude bool) {
 	}
 
 	*props = filtered
+}
+
+func formatText(text string) template.HTML {
+	var html template.HTML
+	lines := strings.Split(text, "\n")
+	preformatted := false
+	for _, line := range lines {
+		r, _ := utf8.DecodeRuneInString(line)
+		indent := unicode.IsSpace(r)
+		if indent && !preformatted {
+			html += "<pre>\n\n"
+			preformatted = true
+		} else if !indent && line != "" && preformatted {
+			html += "</pre>\n"
+			preformatted = false
+		}
+		html += template.HTML(template.HTMLEscapeString(line)) + "\n"
+	}
+	if preformatted {
+		html += "</pre>\n"
+	}
+	return html
 }

--- a/bootstrap/bpdoc/reader.go
+++ b/bootstrap/bpdoc/reader.go
@@ -77,7 +77,7 @@ func (r *Reader) ModuleType(name string, factory reflect.Value) (*ModuleType, er
 	return &ModuleType{
 		Name:    name,
 		PkgPath: pkgPath,
-		Text:    text,
+		Text:    formatText(text),
 	}, nil
 }
 

--- a/bootstrap/bpdoc/reader_test.go
+++ b/bootstrap/bpdoc/reader_test.go
@@ -59,7 +59,7 @@ func TestModuleTypeDocs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if mt.Text != "foo docs.\n" {
+	if mt.Text != "foo docs.\n\n" {
 		t.Errorf("unexpected docs %q", mt.Text)
 	}
 


### PR DESCRIPTION
1. Apply preformatted text (<pre>...</pre>) handling logic to module
type text too. It used to be applied to property texts only.
2. Improve <pre> handling logic itself for better readability.
- Insert a blank line before <pre>.
- Prevent from ending <pre> blocks prematurely by checking if an
unindented line isn't just a blank line between indented lines.
