### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/bootstrap/bpdoc/reader.go
+++ b/bootstrap/bpdoc/reader.go
@@ -81,7 +81,7 @@ func (r *Reader) ModuleType(name string, factory reflect.Value) (*ModuleType, er
 	}, nil
 }
 
-// Return the PropertyStruct associated with a property struct type.  The type should be in the
+// PropertyStruct returns the PropertyStruct associated with a property struct type.  The type should be in the
 // format <package path>.<type name>
 func (r *Reader) PropertyStruct(pkgPath, name string, defaults reflect.Value) (*PropertyStruct, error) {
 	ps := r.getPropertyStruct(pkgPath, name)

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -445,7 +445,7 @@ func (m *baseModuleContext) VisitDepsDepthFirst(visit func(Module)) {
 	m.visitingDep = depInfo{}
 }
 
-// VisitDepsDepthFirst calls pred for each transitive dependency, and if pred returns true calls visit, traversing the
+// VisitDepsDepthFirstIf calls pred for each transitive dependency, and if pred returns true calls visit, traversing the
 // dependency tree in depth first order.  visit will only be called once for any given module, even if there are
 // multiple paths through the dependency tree to the module or multiple direct dependencies with different tags.
 // OtherModuleDependencyTag will return the tag for the first path found to the module.  The return value of pred does
@@ -643,7 +643,7 @@ func (BaseDependencyTag) dependencyTag(DependencyTag) {
 
 var _ DependencyTag = BaseDependencyTag{}
 
-// Split a module into mulitple variants, one for each name in the variationNames
+// CreateVariations splits a module into mulitple variants, one for each name in the variationNames
 // parameter.  It returns a list of new modules in the same order as the variationNames
 // list.
 //
@@ -658,7 +658,7 @@ func (mctx *mutatorContext) CreateVariations(variationNames ...string) []Module 
 	return mctx.createVariations(variationNames, false)
 }
 
-// Split a module into mulitple variants, one for each name in the variantNames
+// CreateLocalVariations splits a module into mulitple variants, one for each name in the variantNames
 // parameter.  It returns a list of new modules in the same order as the variantNames
 // list.
 //
@@ -705,7 +705,7 @@ func (mctx *mutatorContext) Module() Module {
 	return mctx.module.logicModule
 }
 
-// Add a dependency to the given module.
+// AddDependency adds a dependency to the given module.
 // Does not affect the ordering of the current mutator pass, but will be ordered
 // correctly for all future mutator passes.
 func (mctx *mutatorContext) AddDependency(module Module, tag DependencyTag, deps ...string) {
@@ -718,7 +718,7 @@ func (mctx *mutatorContext) AddDependency(module Module, tag DependencyTag, deps
 	}
 }
 
-// Add a dependency from the destination to the given module.
+// AddReverseDependency adds a dependency from the destination to the given module.
 // Does not affect the ordering of the current mutator pass, but will be ordered
 // correctly for all future mutator passes.  All reverse dependencies for a destination module are
 // collected until the end of the mutator pass, sorted by name, and then appended to the destination

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -286,7 +286,7 @@ func (x *Map) getPropertyImpl(name string) (Property *Property, found bool, inde
 	return nil, false, -1
 }
 
-// GetProperty removes the property with the given name, if it exists.
+// RemoveProperty removes the property with the given name, if it exists.
 func (x *Map) RemoveProperty(propertyName string) (removed bool) {
 	_, found, index := x.getPropertyImpl(propertyName)
 	if found {
@@ -445,7 +445,7 @@ func (c Comment) String() string {
 	return string(buf) + "@" + c.Slash.String()
 }
 
-// Return the text of the comment with // or /* and */ stripped
+// Text returns the text of the comment with // or /* and */ stripped
 func (c Comment) Text() string {
 	l := 0
 	for _, comment := range c.Comment {

--- a/pathtools/fs.go
+++ b/pathtools/fs.go
@@ -166,7 +166,7 @@ func (osFs) Stat(path string) (stats os.FileInfo, err error) {
 	return os.Stat(path)
 }
 
-// Returns a list of all directories under dir
+// ListDirsRecursive returns a list of all directories under dir
 func (osFs) ListDirsRecursive(name string, follow ShouldFollowSymlinks) (dirs []string, err error) {
 	return listDirsRecursive(OsFs, name, follow)
 }

--- a/proptools/escape.go
+++ b/proptools/escape.go
@@ -29,7 +29,7 @@ func NinjaEscapeList(slice []string) []string {
 	return slice
 }
 
-// NinjaEscapeList takes a string that may contain characters that are meaningful to ninja
+// NinjaEscape takes a string that may contain characters that are meaningful to ninja
 // ($), and escapes it so it will be passed to bash.  It is not necessary on input,
 // output, or dependency names, those are handled by ModuleContext.Build.  It is generally required
 // on strings from properties in Blueprint files that are used as Args to ModuleContext.Build.  A
@@ -56,7 +56,7 @@ func ShellEscapeList(slice []string) []string {
 
 }
 
-// ShellEscapeList takes string that may contain characters that are meaningful to bash and
+// ShellEscape takes string that may contain characters that are meaningful to bash and
 // escapes it if necessary by wrapping it in single quotes, and replacing internal single quotes with
 // '\'' (one single quote to end the quoting, a shell-escaped single quote to insert a real single
 // quote, and then a single quote to restarting quoting.


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?