### PR TITLE
Avoid exiting with errors in bpglob

### DIFF
--- a/bootstrap/bpglob/bpglob.go
+++ b/bootstrap/bpglob/bpglob.go
@@ -21,7 +21,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/google/blueprint/pathtools"
 )
@@ -71,7 +73,15 @@ func main() {
 
 	_, err := pathtools.GlobWithDepFile(flag.Arg(0), *out, *out+".d", excludes)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
-		os.Exit(1)
+		// Globs here were already run in the primary builder without error.  The only errors here should be if the glob
+		// pattern was made invalid by a change in the pathtools glob implementation, in which case the primary builder
+		// needs to be rerun anyways.  Update the output file with something that will always cause the primary builder
+		// to rerun.
+		s := fmt.Sprintf("%s: error: %s\n", time.Now().Format(time.StampNano), err.Error())
+		err := ioutil.WriteFile(*out, []byte(s), 0666)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
bpglob is only used as a helper to check if the primary builder
needs to rerun due to the results of a glob changing.  A recent
change to glob support in pathtools made a glob format that was
accidentally previously accepted into an error.  If the bad
syntax was used in the most recent primary builder run, and
then an incremental build is performed after picking up the
change that made the syntax invalid, then bpglob will attempt
to rerun before the primary builder, see the now-invalid syntax,
and fail.  This will prevent the primary builder from rerunning,
which would have updated the bpglob rule with a corrected glob
syntax (or failed in the primary builder if the Blueprints file
still had the invalid glob syntax).

Avoid exiting with an error in bpglob.  Instead, write the
error to the output file along with a timestamp so that it is
always dirty, forcing the primary builder to rerun.

Bug: 129411151
Test: m nothing
Change-Id: Ib680570c33662f3c0f1f72425d60a963ed841ba6