### PR TITLE
Put the primary builder into the console pool

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -130,6 +130,7 @@ var (
 			Deps:        blueprint.DepsGCC,
 			Depfile:     "$out.d",
 			Restat:      true,
+			Pool:        blueprint.Console,
 		},
 		"builder", "extra", "generator", "globFile")
 


### PR DESCRIPTION
The primary builder should always be running on its own with no
other processes running in parallel, so put it in the console
pool so that it can print to stdout without buffering.

Bug: 80165685
Test: build with print in Soong
Change-Id: If34ecdb5fa18de7e47c4cd6965d551c504850176