### PR TITLE
Invalidate .bootstrap/build-globs.ninja on working dir change

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -116,6 +116,16 @@ if [ ! -f "$BUILDDIR/.minibootstrap/build-globs.ninja" ]; then
     touch "$BUILDDIR/.minibootstrap/build-globs.ninja"
 fi
 
+BOOTSTRAP_GLOBFILE="${BUILDDIR}/.bootstrap/build-globs.ninja"
+if [ -f "${BOOTSTRAP_GLOBFILE}" ]; then
+    PREV_DIR=$(sed -n -e "s/^g.bootstrap.buildDir = \(.*\)/\1/p" "${BOOTSTRAP_GLOBFILE}")
+    if [ "${PREV_DIR}" != "${BUILDDIR}" ] ; then
+        # BOOTSTRAP_GLOBFILE is invalid if BUILDDIR has changed
+        # Invalidate it so that the bootstrap builder can be built
+        cat /dev/null > "${BOOTSTRAP_GLOBFILE}"
+    fi
+fi
+
 echo "BLUEPRINT_BOOTSTRAP_VERSION=2" > $BUILDDIR/.blueprint.bootstrap
 echo "SRCDIR=\"${SRCDIR}\"" >> $BUILDDIR/.blueprint.bootstrap
 echo "BLUEPRINTDIR=\"${BLUEPRINTDIR}\"" >> $BUILDDIR/.blueprint.bootstrap


### PR DESCRIPTION
When a build output directory is re-bootstrapped and the working
directory is changed, an error like the following is encountered:

 [1/1] build/.minibootstrap/minibp build/.bootstrap/build.ninja
 ninja: error: 'tests/build/.minibootstrap/bpglob', needed by 'tests/build/.glob/tests/resources/__c.glob', missing and no known rule to make it

This issue is not reproducible with just the Blueprint repo (as it
doesn't use globs). I suspect this is not reproducible in soong, where
the working directory is fixed. This can be reproduced with
https://github.com/ARM-software/bob-build/commit/5c0c49a10c6e8f00411645270e98c4453fc98377:

 tests/bootstrap -o tests/build
 tests/build/config
 tests/build/buildme
 cd tests
 ./bootstrap -o build
 build/buildme

The issue is that the file tests/build/.bootstrap/build-globs.ninja
identifies the build directory relative to the old working
directory. This causes the bootstrap builder to fail as bpglob can't
be found. I think the primary builder would fix this if it could be
executed.

An equivalent fix for this was applied to Bob's bootstrap.bash which
can be removed if this is handled in Blueprint.

Blueprint commit c708e1c9e3 addresses a related problem where bpglob
no longer handles an old glob pattern. In this case, bpglob can't be
run.

Change-Id: Ia5647bd7f96af31a819d99076486c84574c765d3
Signed-off-by: David Kilroy <david.kilroy@arm.com>