### PR TITLE
Revert "Put the primary builder into the console pool"

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -130,7 +130,6 @@ var (
 			Deps:        blueprint.DepsGCC,
 			Depfile:     "$out.d",
 			Restat:      true,
-			Pool:        blueprint.Console,
 		},
 		"builder", "extra", "generator", "globFile")
 


### PR DESCRIPTION
This reverts commit 8ea996f61dd4f10e0cef5e2dc328dc071c3b7db5.

Having the primary builder hinders automatic error reporting
by separating the error message from the failure status.