### PR TITLE
Add SetDefaultDependencyVariation

### DIFF
--- a/context.go
+++ b/context.go
@@ -1153,7 +1153,7 @@ func (c *Context) cloneLogicModule(origModule *moduleInfo) (Module, []interface{
 }
 
 func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
-	variationNames []string) ([]*moduleInfo, []error) {
+	defaultVariationName *string, variationNames []string) ([]*moduleInfo, []error) {
 
 	if len(variationNames) == 0 {
 		panic(fmt.Errorf("mutator %q passed zero-length variation list for module %q",
@@ -1198,7 +1198,7 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 
 		newModules = append(newModules, newModule)
 
-		newErrs := c.convertDepsToVariation(newModule, mutatorName, variationName)
+		newErrs := c.convertDepsToVariation(newModule, mutatorName, variationName, defaultVariationName)
 		if len(newErrs) > 0 {
 			errs = append(errs, newErrs...)
 		}
@@ -1215,7 +1215,7 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 }
 
 func (c *Context) convertDepsToVariation(module *moduleInfo,
-	mutatorName, variationName string) (errs []error) {
+	mutatorName, variationName string, defaultVariationName *string) (errs []error) {
 
 	for i, dep := range module.directDeps {
 		if dep.module.logicModule == nil {
@@ -1224,6 +1224,15 @@ func (c *Context) convertDepsToVariation(module *moduleInfo,
 				if m.variant[mutatorName] == variationName {
 					newDep = m
 					break
+				}
+			}
+			if newDep == nil && defaultVariationName != nil {
+				// give it a second chance; match with defaultVariationName
+				for _, m := range dep.module.splitModules {
+					if m.variant[mutatorName] == *defaultVariationName {
+						newDep = m
+						break
+					}
 				}
 			}
 			if newDep == nil {


### PR DESCRIPTION
SetDefaultDependencyVariation sets the variation name that will be used
when a dangling dependency is found while a module is being split. A
dangling dependency can occur if a module is split to a variant that one
of its dependencies is not split into. When the default variation is not
set, such dangling dependency is a hard error. But with the new
function, the default variation can be set and subsequent calls to
CreateVariations and its variations on the same context uses the default
variation when necessary.

(If even the default variation does not exist for the dependent module,
it is an hard error)

Note that this is different from calling SetDependencyVariation("foo")
followed by CreateVariations("foo", "bar"). In that case, regardless of
whether a dependency of the current module has the variant 'bar' or not,
only the 'foo' variant is chosen.

With SetDefaultDependencyVariation("foo") followed by
CreateVariations("foo", "bar"), 'foo' variant is used only when the
'bar' variant of the current module depends on a module that does not
have 'bar' variant.

Bug: 138103882
Test: m
Change-Id: I4520ca87487994de024fdbacda3bef6636225f0d