### PR TITLE
Fix checkCalledFromInit

### DIFF
--- a/package_ctx.go
+++ b/package_ctx.go
@@ -158,8 +158,9 @@ func callerName(skip int) (pkgPath, funcName string, ok bool) {
 	if n != 1 {
 		return "", "", false
 	}
-
-	f := runtime.FuncForPC(pc[0]).Name()
+	frames := runtime.CallersFrames(pc[:])
+	frame, _ := frames.Next()
+	f := frame.Function
 	s := pkgPathRe.FindStringSubmatch(f)
 	if len(s) < 3 {
 		panic(fmt.Errorf("failed to extract package path and function name from %q", f))


### PR DESCRIPTION
This function checks if it is called from init() by looking into
callers. By the way, it may fail when init() is inlined.

To fix this, CallersFrames() is used to translate PCs into symbolic
information accounting for inlined functions.

Test: go test ./...
Change-Id: I18b3c3ffdaf71f775e3522c87607aec5df7b09c5