### PR TITLE
Add support for module variant aliases

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -24,6 +24,7 @@ bootstrap_go_package {
     testSrcs: [
         "context_test.go",
         "glob_test.go",
+        "module_ctx_test.go",
         "ninja_strings_test.go",
         "ninja_writer_test.go",
         "splice_modules_test.go",

--- a/context.go
+++ b/context.go
@@ -242,6 +242,9 @@ type Variation struct {
 type variationMap map[string]string
 
 func (vm variationMap) clone() variationMap {
+	if vm == nil {
+		return nil
+	}
 	newVm := make(variationMap)
 	for k, v := range vm {
 		newVm[k] = v
@@ -1178,6 +1181,9 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 		}
 
 		newVariant := origModule.variant.clone()
+		if newVariant == nil {
+			newVariant = make(variationMap)
+		}
 		newVariant[mutatorName] = variationName
 
 		m := *origModule
@@ -1521,10 +1527,11 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 	var newVariant variationMap
 	if !far {
 		newVariant = module.dependencyVariant.clone()
-	} else {
-		newVariant = make(variationMap)
 	}
 	for _, v := range variations {
+		if newVariant == nil {
+			newVariant = make(variationMap)
+		}
 		newVariant[v.Mutator] = v.Variation
 	}
 

--- a/context_test.go
+++ b/context_test.go
@@ -188,7 +188,7 @@ func TestWalkDeps(t *testing.T) {
 
 	var outputDown string
 	var outputUp string
-	topModule := ctx.modulesFromName("A", nil)[0]
+	topModule := ctx.moduleGroupFromName("A", nil).modules[0]
 	ctx.walkDeps(topModule, false,
 		func(dep depInfo, parent *moduleInfo) bool {
 			outputDown += ctx.ModuleName(dep.module.logicModule)
@@ -280,7 +280,7 @@ func TestWalkDepsDuplicates(t *testing.T) {
 
 	var outputDown string
 	var outputUp string
-	topModule := ctx.modulesFromName("A", nil)[0]
+	topModule := ctx.moduleGroupFromName("A", nil).modules[0]
 	ctx.walkDeps(topModule, true,
 		func(dep depInfo, parent *moduleInfo) bool {
 			outputDown += ctx.ModuleName(dep.module.logicModule)
@@ -334,10 +334,10 @@ func TestCreateModule(t *testing.T) {
 		t.FailNow()
 	}
 
-	a := ctx.modulesFromName("A", nil)[0].logicModule.(*fooModule)
-	b := ctx.modulesFromName("B", nil)[0].logicModule.(*barModule)
-	c := ctx.modulesFromName("C", nil)[0].logicModule.(*barModule)
-	d := ctx.modulesFromName("D", nil)[0].logicModule.(*fooModule)
+	a := ctx.moduleGroupFromName("A", nil).modules[0].logicModule.(*fooModule)
+	b := ctx.moduleGroupFromName("B", nil).modules[0].logicModule.(*barModule)
+	c := ctx.moduleGroupFromName("C", nil).modules[0].logicModule.(*barModule)
+	d := ctx.moduleGroupFromName("D", nil).modules[0].logicModule.(*fooModule)
 
 	checkDeps := func(m Module, expected string) {
 		var deps []string

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -838,6 +838,9 @@ func (mctx *mutatorContext) createVariations(variationNames []string, local bool
 	for i, module := range modules {
 		ret = append(ret, module.logicModule)
 		if !local {
+			if module.dependencyVariant == nil {
+				module.dependencyVariant = make(variationMap)
+			}
 			module.dependencyVariant[mctx.name] = variationNames[i]
 		}
 	}

--- a/module_ctx_test.go
+++ b/module_ctx_test.go
@@ -1,0 +1,197 @@
+// Copyright 2019 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blueprint
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type moduleCtxTestModule struct {
+	SimpleName
+}
+
+func newModuleCtxTestModule() (Module, []interface{}) {
+	m := &moduleCtxTestModule{}
+	return m, []interface{}{&m.SimpleName.Properties}
+}
+
+func (f *moduleCtxTestModule) GenerateBuildActions(ModuleContext) {
+}
+
+func noCreateAliasMutator(name string) func(ctx BottomUpMutatorContext) {
+	return func(ctx BottomUpMutatorContext) {
+		if ctx.ModuleName() == name {
+			ctx.CreateVariations("a", "b")
+		}
+	}
+}
+
+func createAliasMutator(name string) func(ctx BottomUpMutatorContext) {
+	return func(ctx BottomUpMutatorContext) {
+		if ctx.ModuleName() == name {
+			ctx.CreateVariations("a", "b")
+			ctx.AliasVariation("b")
+		}
+	}
+}
+
+func addVariantDepsMutator(variants []Variation, tag DependencyTag, from, to string) func(ctx BottomUpMutatorContext) {
+	return func(ctx BottomUpMutatorContext) {
+		if ctx.ModuleName() == from {
+			ctx.AddVariationDependencies(variants, tag, to)
+		}
+	}
+}
+
+func TestAliases(t *testing.T) {
+	runWithFailures := func(ctx *Context, expectedErr string) {
+		t.Helper()
+		bp := `
+			test {
+				name: "foo",
+			}
+
+			test {
+				name: "bar",
+			}
+		`
+
+		mockFS := map[string][]byte{
+			"Blueprints": []byte(bp),
+		}
+
+		ctx.MockFileSystem(mockFS)
+
+		_, errs := ctx.ParseFileList(".", []string{"Blueprints"})
+		if len(errs) > 0 {
+			t.Errorf("unexpected parse errors:")
+			for _, err := range errs {
+				t.Errorf("  %s", err)
+			}
+		}
+
+		_, errs = ctx.ResolveDependencies(nil)
+		if len(errs) > 0 {
+			if expectedErr == "" {
+				t.Errorf("unexpected dep errors:")
+				for _, err := range errs {
+					t.Errorf("  %s", err)
+				}
+			} else {
+				for _, err := range errs {
+					if strings.Contains(err.Error(), expectedErr) {
+						continue
+					} else {
+						t.Errorf("unexpected dep error: %s", err)
+					}
+				}
+			}
+		} else if expectedErr != "" {
+			t.Errorf("missing dep error: %s", expectedErr)
+		}
+	}
+
+	run := func(ctx *Context) {
+		t.Helper()
+		runWithFailures(ctx, "")
+	}
+
+	t.Run("simple", func(t *testing.T) {
+		// Creates a module "bar" with variants "a" and "b" and alias "" -> "b".
+		// Tests a dependency from "foo" to "bar" variant "b" through alias "".
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", addVariantDepsMutator(nil, nil, "foo", "bar"))
+
+		run(ctx)
+
+		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
+		barB := ctx.moduleGroupFromName("bar", nil).modules[1]
+
+		if g, w := barB.variantName, "b"; g != w {
+			t.Fatalf("expected bar.modules[1] variant to be %q, got %q", w, g)
+		}
+
+		if g, w := foo.forwardDeps, []*moduleInfo{barB}; !reflect.DeepEqual(g, w) {
+			t.Fatalf("expected foo deps to be %q, got %q", w, g)
+		}
+	})
+
+	t.Run("chained", func(t *testing.T) {
+		// Creates a module "bar" with variants "a_a", "a_b", "b_a" and "b_b" and aliases "" -> "b_b",
+		// "a" -> "a_b", and "b" -> "b_b".
+		// Tests a dependency from "foo" to "bar" variant "b_b" through alias "".
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator(nil, nil, "foo", "bar"))
+
+		run(ctx)
+
+		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
+		barBB := ctx.moduleGroupFromName("bar", nil).modules[3]
+
+		if g, w := barBB.variantName, "b_b"; g != w {
+			t.Fatalf("expected bar.modules[3] variant to be %q, got %q", w, g)
+		}
+
+		if g, w := foo.forwardDeps, []*moduleInfo{barBB}; !reflect.DeepEqual(g, w) {
+			t.Fatalf("expected foo deps to be %q, got %q", w, g)
+		}
+	})
+
+	t.Run("chained2", func(t *testing.T) {
+		// Creates a module "bar" with variants "a_a", "a_b", "b_a" and "b_b" and aliases "" -> "b_b",
+		// "a" -> "a_b", and "b" -> "b_b".
+		// Tests a dependency from "foo" to "bar" variant "a_b" through alias "a".
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator([]Variation{{"1", "a"}}, nil, "foo", "bar"))
+
+		run(ctx)
+
+		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
+		barAB := ctx.moduleGroupFromName("bar", nil).modules[1]
+
+		if g, w := barAB.variantName, "a_b"; g != w {
+			t.Fatalf("expected bar.modules[1] variant to be %q, got %q", w, g)
+		}
+
+		if g, w := foo.forwardDeps, []*moduleInfo{barAB}; !reflect.DeepEqual(g, w) {
+			t.Fatalf("expected foo deps to be %q, got %q", w, g)
+		}
+	})
+
+	t.Run("removed dangling alias", func(t *testing.T) {
+		// Creates a module "bar" with variants "a" and "b" and aliases "" -> "b", then splits the variants into
+		// "a_a", "a_b", "b_a" and "b_b" without creating new aliases.
+		// Tests a dependency from "foo" to removed "bar" alias "" fails.
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", noCreateAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator(nil, nil, "foo", "bar"))
+
+		runWithFailures(ctx, `dependency "bar" of "foo" missing variant:`+"\n  \n"+
+			"available variants:"+
+			"\n  1:a, 2:a\n  1:a, 2:b\n  1:b, 2:a\n  1:b, 2:b")
+	})
+}

--- a/visit_test.go
+++ b/visit_test.go
@@ -149,13 +149,13 @@ func setupVisitTest(t *testing.T) *Context {
 func TestVisit(t *testing.T) {
 	ctx := setupVisitTest(t)
 
-	topModule := ctx.modulesFromName("A", nil)[0].logicModule.(*visitModule)
+	topModule := ctx.moduleGroupFromName("A", nil).modules[0].logicModule.(*visitModule)
 	assertString(t, topModule.properties.VisitDepsDepthFirst, "FEDCB")
 	assertString(t, topModule.properties.VisitDepsDepthFirstIf, "FEDC")
 	assertString(t, topModule.properties.VisitDirectDeps, "B")
 	assertString(t, topModule.properties.VisitDirectDepsIf, "")
 
-	eModule := ctx.modulesFromName("E", nil)[0].logicModule.(*visitModule)
+	eModule := ctx.moduleGroupFromName("E", nil).modules[0].logicModule.(*visitModule)
 	assertString(t, eModule.properties.VisitDepsDepthFirst, "F")
 	assertString(t, eModule.properties.VisitDepsDepthFirstIf, "F")
 	assertString(t, eModule.properties.VisitDirectDeps, "FF")


### PR DESCRIPTION
Adding a dependency on a module with variants can be problematic if the code adding the dependency is not aware of every mutator that has created variants.  Add an AliasVariations to BottomUpMutatorContext, which allows a mutator to alias the original variant of a module to one of the new variants of the module, which will allow future dependencies to be added using the original list of variations.  The aliases are transient, and only exist until the next mutator that calls CreateVariations when visiting the module without also calling AliasVariations.
