### PR TITLE
Slice properties can be replaced

### DIFF
--- a/proptools/extend.go
+++ b/proptools/extend.go
@@ -150,6 +150,7 @@ type Order int
 const (
 	Append Order = iota
 	Prepend
+	Replace
 )
 
 type ExtendPropertyFilterFunc func(property string,
@@ -170,6 +171,12 @@ func OrderPrepend(property string,
 	dstField, srcField reflect.StructField,
 	dstValue, srcValue interface{}) (Order, error) {
 	return Prepend, nil
+}
+
+func OrderReplace(property string,
+	dstField, srcField reflect.StructField,
+	dstValue, srcValue interface{}) (Order, error) {
+	return Replace, nil
 }
 
 type ExtendPropertyError struct {
@@ -428,8 +435,11 @@ func ExtendBasicType(dstFieldValue, srcFieldValue reflect.Value, order Order) {
 		if prepend {
 			newSlice = reflect.AppendSlice(newSlice, srcFieldValue)
 			newSlice = reflect.AppendSlice(newSlice, dstFieldValue)
-		} else {
+		} else if order == Append {
 			newSlice = reflect.AppendSlice(newSlice, dstFieldValue)
+			newSlice = reflect.AppendSlice(newSlice, srcFieldValue)
+		} else {
+			// replace
 			newSlice = reflect.AppendSlice(newSlice, srcFieldValue)
 		}
 		dstFieldValue.Set(newSlice)


### PR DESCRIPTION
override_* in Soong requires a module to override certain properties of
other module. In that case, values of a slice property (e.g. []string)
should be replaced by the same property value in the overriding module.
However, since proptools only supports Append and Prepend orders where
the original values are kept for slice properties, the behavior
couldn't be implemented. To support the use case, Replace order is
introduced, in which case slice property values are completely replaced.
For other types of properties, the Replace order behaves exactly the
same as the Append order.

Bug: 144338929
Test: m

Change-Id: Iae9feda035177fe6a22e6e8319c0fdaa9e08e85e