### PR TITLE
prettyPrint missing mutators

### DIFF
--- a/context.go
+++ b/context.go
@@ -1272,8 +1272,20 @@ func (c *Context) prettyPrintVariant(variant variationMap) string {
 			names = append(names, m+":"+v)
 		}
 	}
-
-	return strings.Join(names, ", ")
+	var missing string
+	if len(names) < len(variant) {
+		variantClone := variant.clone()
+		for _, m := range c.variantMutatorNames {
+			delete(variantClone, m)
+		}
+		unknownVariants := make([]string, 0, len(variant)-len(names))
+		for m, v := range variantClone {
+			unknownVariants = append(unknownVariants, m+":"+v)
+		}
+		sort.Strings(unknownVariants)
+		missing = " (" + strings.Join(unknownVariants, ", ") + ")"
+	}
+	return strings.Join(names, ", ") + missing
 }
 
 func (c *Context) prettyPrintGroupVariants(group *moduleGroup) string {

--- a/context_test.go
+++ b/context_test.go
@@ -508,3 +508,16 @@ func TestParseFailsForModuleWithoutName(t *testing.T) {
 		t.Errorf("Incorrect errors; expected:\n%s\ngot:\n%s", expectedErrs, errs)
 	}
 }
+
+func TestPrettyPrintMissingMutators(t *testing.T) {
+	ctx := NewContext()
+	ctx.RegisterBottomUpMutator("known_mutator", func(ctx BottomUpMutatorContext) {})
+	actual := ctx.prettyPrintVariant(variationMap{
+		"known_mutator":   "known_variation",
+		"unknown_mutator": "unknown_variation",
+	})
+	expected := "known_mutator:known_variation (unknown_mutator:unknown_variation)"
+	if actual != expected {
+		t.Errorf("Incorrect variation; expected:\n%s\ngot:\n%s", expected, actual)
+	}
+}


### PR DESCRIPTION
prettyPrintVariant() prints only for the known mutators. But when there
are unknown mutators they are missing from the error message. This leads
to somewhat wierd message like following:

dependency "foo" of "bar" missing variant:
  A:a, B:b
available variants:
  A:a, B:b

This can happend when we call AddVariationDependencies() like following:
  ctx.AddVariationDependencies([]Variation{
  	{"A", "a"},
  	{"B", "b"},
  	{"C", "c"},
  }, ...)
when there are only "A" and "B" registered.

By printing missing variants, it will print like following:

dependency "foo" of "bar" missing variant:
  A:a, B:b (C:c)
available variants:
  A:a, B:b