### PR TITLE
Add Context.SetFs

### DIFF
--- a/context.go
+++ b/context.go
@@ -889,6 +889,10 @@ func (c *Context) MockFileSystem(files map[string][]byte) {
 	c.fs = pathtools.MockFs(files)
 }
 
+func (c *Context) SetFs(fs pathtools.FileSystem) {
+	c.fs = fs
+}
+
 // openAndParse opens and parses a single Blueprints file, and returns the results
 func (c *Context) openAndParse(filename string, scope *parser.Scope, rootDir string,
 	parent *fileParseContext) (file *parser.File,


### PR DESCRIPTION
Allow the primary builder to set the filesystem directly.

Bug: 146437378
Test: m checkbuild
Change-Id: Ic8cc3e6a03943d5f47b041a66df6a11f4336c97b