### PR TITLE
Add EarlyModuleContext.BlueprintsFile

### DIFF
--- a/module_ctx.go
+++ b/module_ctx.go
@@ -137,6 +137,10 @@ type EarlyModuleContext interface {
 	// RegisterModuleType.
 	ModuleType() string
 
+	// BlueprintFile returns the name of the blueprint file that contains the definition of this
+	// module.
+	BlueprintsFile() string
+
 	// Config returns the config object that was passed to Context.PrepareBuildActions.
 	Config() interface{}
 
@@ -349,6 +353,10 @@ func (d *baseModuleContext) ContainsProperty(name string) bool {
 
 func (d *baseModuleContext) ModuleDir() string {
 	return filepath.Dir(d.module.relBlueprintsFile)
+}
+
+func (d *baseModuleContext) BlueprintsFile() string {
+	return d.module.relBlueprintsFile
 }
 
 func (d *baseModuleContext) Config() interface{} {


### PR DESCRIPTION
EarlyModuleContext already has ModuleDir, add BlueprintsFile too.

Test: m checkbuild
Change-Id: Ia9e0c724562e1461dfcd5e01f56ff8abbea2ac06