### PR TITLE
Speed up incremental builds after globs

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -194,25 +194,6 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		out = ioutil.Discard
 	}
 
-	err = ctx.WriteBuildFile(out)
-	if err != nil {
-		fatalf("error writing Ninja file contents: %s", err)
-	}
-
-	if buf != nil {
-		err = buf.Flush()
-		if err != nil {
-			fatalf("error flushing Ninja file contents: %s", err)
-		}
-	}
-
-	if f != nil {
-		err = f.Close()
-		if err != nil {
-			fatalf("error closing Ninja file: %s", err)
-		}
-	}
-
 	if globFile != "" {
 		buffer, errs := generateGlobNinjaFile(ctx.Globs)
 		if len(errs) > 0 {
@@ -229,6 +210,25 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		err := deptools.WriteDepFile(absolutePath(depFile), outFile, deps)
 		if err != nil {
 			fatalf("error writing depfile: %s", err)
+		}
+	}
+
+	err = ctx.WriteBuildFile(out)
+	if err != nil {
+		fatalf("error writing Ninja file contents: %s", err)
+	}
+
+	if buf != nil {
+		err = buf.Flush()
+		if err != nil {
+			fatalf("error flushing Ninja file contents: %s", err)
+		}
+	}
+
+	if f != nil {
+		err = f.Close()
+		if err != nil {
+			fatalf("error closing Ninja file: %s", err)
 		}
 	}
 

--- a/bootstrap/glob.go
+++ b/bootstrap/glob.go
@@ -131,8 +131,14 @@ func (s *globSingleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 			depFile := fileListFile + ".d"
 
 			fileList := strings.Join(g.Files, "\n") + "\n"
-			pathtools.WriteFileIfChanged(fileListFile, []byte(fileList), 0666)
-			deptools.WriteDepFile(depFile, fileListFile, g.Deps)
+			err := pathtools.WriteFileIfChanged(absolutePath(fileListFile), []byte(fileList), 0666)
+			if err != nil {
+				panic(fmt.Errorf("error writing %s: %s", fileListFile, err))
+			}
+			err = deptools.WriteDepFile(absolutePath(depFile), fileListFile, g.Deps)
+			if err != nil {
+				panic(fmt.Errorf("error writing %s: %s", depFile, err))
+			}
 
 			GlobFile(ctx, g.Pattern, g.Excludes, fileListFile, depFile)
 		} else {


### PR DESCRIPTION
Two issues with globs were causing unnecessary primary builder reruns on an incremental build after a clean build or after changing a glob result.