### PR TITLE
Make FilterPropertyStructSharded smarter

### DIFF
--- a/bootstrap/bpdoc/bpdoc.go
+++ b/bootstrap/bpdoc/bpdoc.go
@@ -145,14 +145,6 @@ func assembleModuleTypeInfo(r *Reader, name string, factory reflect.Value,
 				return nil, fmt.Errorf("nesting point %q not found", nestedName)
 			}
 
-			key, value, err := proptools.HasFilter(nestPoint.Tag)
-			if err != nil {
-				return nil, err
-			}
-			if key != "" {
-				nested.IncludeByTag(key, value)
-			}
-
 			nestPoint.Nest(nested)
 		}
 		mt.PropertyStructs = append(mt.PropertyStructs, ps)

--- a/proptools/filter_test.go
+++ b/proptools/filter_test.go
@@ -16,6 +16,7 @@ package proptools
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -233,6 +234,284 @@ func TestFilterPropertyStruct(t *testing.T) {
 			expected := reflect.TypeOf(test.out)
 			if out != expected {
 				t.Errorf("expected type %v, got %v", expected, out)
+			}
+		})
+	}
+}
+
+func TestFilterPropertyStructSharded(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxNameSize int
+		in          interface{}
+		out         []interface{}
+		filtered    bool
+	}{
+		// Property tests
+		{
+			name:        "basic",
+			maxNameSize: 20,
+			in: &struct {
+				A *string `keep:"true"`
+				B *string `keep:"true"`
+				C *string
+			}{},
+			out: []interface{}{
+				&struct {
+					A *string
+				}{},
+				&struct {
+					B *string
+				}{},
+			},
+			filtered: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, filtered := filterPropertyStruct(reflect.TypeOf(test.in), "", test.maxNameSize,
+				func(field reflect.StructField, prefix string) (bool, reflect.StructField) {
+					if HasTag(field, "keep", "true") {
+						field.Tag = ""
+						return true, field
+					}
+					return false, field
+				})
+			if filtered != test.filtered {
+				t.Errorf("expected filtered %v, got %v", test.filtered, filtered)
+			}
+			var expected []reflect.Type
+			for _, t := range test.out {
+				expected = append(expected, reflect.TypeOf(t))
+			}
+			if !reflect.DeepEqual(out, expected) {
+				t.Errorf("expected type %v, got %v", expected, out)
+			}
+		})
+	}
+}
+
+func Test_fieldToTypeNameSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		field reflect.StructField
+	}{
+		{
+			name: "string",
+			field: reflect.StructField{
+				Name: "Foo",
+				Type: reflect.TypeOf(""),
+			},
+		},
+		{
+			name: "string pointer",
+			field: reflect.StructField{
+				Name: "Foo",
+				Type: reflect.TypeOf(StringPtr("")),
+			},
+		},
+		{
+			name: "anonymous struct",
+			field: reflect.StructField{
+				Name: "Foo",
+				Type: reflect.TypeOf(struct{ foo string }{}),
+			},
+		}, {
+			name: "anonymous struct pointer",
+			field: reflect.StructField{
+				Name: "Foo",
+				Type: reflect.TypeOf(&struct{ foo string }{}),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			typeName := reflect.StructOf([]reflect.StructField{test.field}).String()
+			typeName = strings.TrimPrefix(typeName, "struct { ")
+			typeName = strings.TrimSuffix(typeName, " }")
+			if g, w := fieldToTypeNameSize(test.field, true), len(typeName); g != w {
+				t.Errorf("want fieldToTypeNameSize(..., true) = %v, got %v", w, g)
+			}
+			if g, w := fieldToTypeNameSize(test.field, false), len(typeName)-len(test.field.Type.String()); g != w {
+				t.Errorf("want fieldToTypeNameSize(..., false) = %v, got %v", w, g)
+			}
+		})
+	}
+}
+
+func Test_filterPropertyStructFields(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name            string
+		maxTypeNameSize int
+		in              interface{}
+		out             []interface{}
+	}{
+		{
+			name:            "empty",
+			maxTypeNameSize: -1,
+			in:              struct{}{},
+			out:             nil,
+		},
+		{
+			name:            "one",
+			maxTypeNameSize: -1,
+			in: struct {
+				A *string
+			}{},
+			out: []interface{}{
+				struct {
+					A *string
+				}{},
+			},
+		},
+		{
+			name:            "two",
+			maxTypeNameSize: 20,
+			in: struct {
+				A *string
+				B *string
+			}{},
+			out: []interface{}{
+				struct {
+					A *string
+				}{},
+				struct {
+					B *string
+				}{},
+			},
+		},
+		{
+			name:            "nested",
+			maxTypeNameSize: 36,
+			in: struct {
+				AAAAA struct {
+					A string
+				}
+				BBBBB struct {
+					B string
+				}
+			}{},
+			out: []interface{}{
+				struct {
+					AAAAA struct {
+						A string
+					}
+				}{},
+				struct {
+					BBBBB struct {
+						B string
+					}
+				}{},
+			},
+		},
+		{
+			name:            "nested pointer",
+			maxTypeNameSize: 37,
+			in: struct {
+				AAAAA *struct {
+					A string
+				}
+				BBBBB *struct {
+					B string
+				}
+			}{},
+			out: []interface{}{
+				struct {
+					AAAAA *struct {
+						A string
+					}
+				}{},
+				struct {
+					BBBBB *struct {
+						B string
+					}
+				}{},
+			},
+		},
+		{
+			name:            "doubly nested",
+			maxTypeNameSize: 49,
+			in: struct {
+				AAAAA struct {
+					A struct {
+						A string
+					}
+				}
+				BBBBB struct {
+					B struct {
+						B string
+					}
+				}
+			}{},
+			out: []interface{}{
+				struct {
+					AAAAA struct {
+						A struct {
+							A string
+						}
+					}
+				}{},
+				struct {
+					BBBBB struct {
+						B struct {
+							B string
+						}
+					}
+				}{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inType := reflect.TypeOf(test.in)
+			var in []reflect.StructField
+			for i := 0; i < inType.NumField(); i++ {
+				in = append(in, inType.Field(i))
+			}
+
+			keep := func(field reflect.StructField, string string) (bool, reflect.StructField) {
+				return true, field
+			}
+
+			// Test that maxTypeNameSize is the
+			if test.maxTypeNameSize > 0 {
+				correctPanic := false
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							if _, ok := r.(cantFitPanic); ok {
+								correctPanic = true
+							} else {
+								panic(r)
+							}
+						}
+					}()
+
+					_, _ = filterPropertyStructFields(in, "", test.maxTypeNameSize-1, keep)
+				}()
+
+				if !correctPanic {
+					t.Errorf("filterPropertyStructFields() with size-1 should produce cantFitPanic")
+				}
+			}
+
+			filteredFieldsShards, _ := filterPropertyStructFields(in, "", test.maxTypeNameSize, keep)
+
+			var out []interface{}
+			for _, filteredFields := range filteredFieldsShards {
+				typ := reflect.StructOf(filteredFields)
+				if test.maxTypeNameSize > 0 && len(typ.String()) > test.maxTypeNameSize {
+					t.Errorf("out %q expected size <= %d, got %d",
+						typ.String(), test.maxTypeNameSize, len(typ.String()))
+				}
+				out = append(out, reflect.Zero(typ).Interface())
+			}
+
+			if g, w := out, test.out; !reflect.DeepEqual(g, w) {
+				t.Errorf("filterPropertyStructFields() want %v, got %v", w, g)
 			}
 		})
 	}

--- a/proptools/unpack_test.go
+++ b/proptools/unpack_test.go
@@ -16,7 +16,6 @@ package proptools
 
 import (
 	"bytes"
-	"fmt"
 	"reflect"
 	"testing"
 	"text/scanner"
@@ -215,39 +214,6 @@ var validUnpackTestCases = []struct {
 				},
 				Bar: false,
 				Baz: []string{"def", "ghi"},
-			},
-		},
-	},
-
-	{
-		input: `
-			m {
-				nested: {
-					foo: "abc",
-				},
-				bar: false,
-				baz: ["def", "ghi"],
-			}
-		`,
-		output: []interface{}{
-			struct {
-				Nested struct {
-					Foo string
-				} `blueprint:"filter(allowNested:\"true\")"`
-				Bar bool
-				Baz []string
-			}{
-				Nested: struct{ Foo string }{
-					Foo: "",
-				},
-				Bar: false,
-				Baz: []string{"def", "ghi"},
-			},
-		},
-		errs: []error{
-			&UnpackError{
-				Err: fmt.Errorf("filtered field nested.foo cannot be set in a Blueprint file"),
-				Pos: mkpos(30, 4, 9),
 			},
 		},
 	},


### PR DESCRIPTION
FilterPropertyStructSharded was just sharding the top level
properties into groups of 10.  For nested property structs
this can be insufficient - there could be a single top level
property with many properties below it.

Take a maximum name size, and track the size used by parent
structs to determine when sharding a nested struct is necessary.

Bug: 146234651
Test: filter_test.go
Change-Id: I5b5ed11ea27a0325b2fd6c2c3fb427ea1e2af0c2