### PR TITLE
Support unpacking capitalized property names

### DIFF
--- a/proptools/proptools.go
+++ b/proptools/proptools.go
@@ -16,19 +16,33 @@ package proptools
 
 import (
 	"reflect"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
 
+// PropertyNameForField converts the name of a field in property struct to the property name that
+// might appear in a Blueprints file.  Since the property struct fields must always be exported
+// to be accessed with reflection and the canonical Blueprints style is lowercased names, it
+// lower cases the first rune in the field name unless the field name contains multiple runes none
+// of which are lowercase, in which case it returns the field name as-is.
 func PropertyNameForField(fieldName string) string {
 	r, size := utf8.DecodeRuneInString(fieldName)
 	propertyName := string(unicode.ToLower(r))
+	if size == len(fieldName) {
+		return propertyName
+	}
+	if strings.IndexFunc(fieldName[size:], unicode.IsLower) == -1 {
+		return fieldName
+	}
 	if len(fieldName) > size {
 		propertyName += fieldName[size:]
 	}
 	return propertyName
 }
 
+// FieldNameForProperty converts the name of a property that might appear in a Blueprints file to
+// the name of a field in property struct by uppercasing the first rune.
 func FieldNameForProperty(propertyName string) string {
 	r, size := utf8.DecodeRuneInString(propertyName)
 	fieldName := string(unicode.ToUpper(r))

--- a/proptools/proptools_test.go
+++ b/proptools/proptools_test.go
@@ -1,0 +1,94 @@
+// Copyright 2020 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proptools
+
+import "testing"
+
+func TestPropertyNameForField(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "short",
+			input: "S",
+			want:  "s",
+		},
+		{
+			name:  "long",
+			input: "String",
+			want:  "string",
+		},
+		{
+			name:  "uppercase",
+			input: "STRING",
+			want:  "STRING",
+		},
+		{
+			name:  "mixed",
+			input: "StRiNg",
+			want:  "stRiNg",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PropertyNameForField(tt.input); got != tt.want {
+				t.Errorf("PropertyNameForField(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFieldNameForProperty(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "short lowercase",
+			input: "s",
+			want:  "S",
+		},
+		{
+			name:  "short uppercase",
+			input: "S",
+			want:  "S",
+		},
+		{
+			name:  "long lowercase",
+			input: "string",
+			want:  "String",
+		},
+		{
+			name:  "long uppercase",
+			input: "STRING",
+			want:  "STRING",
+		},
+		{
+			name:  "mixed",
+			input: "StRiNg",
+			want:  "StRiNg",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FieldNameForProperty(tt.input); got != tt.want {
+				t.Errorf("FieldNameForProperty(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/proptools/unpack_test.go
+++ b/proptools/unpack_test.go
@@ -508,6 +508,21 @@ var validUnpackTestCases = []struct {
 			},
 		},
 	},
+	// Captitalized property
+	{
+		input: `
+			m {
+				CAPITALIZED: "foo",
+			}
+		`,
+		output: []interface{}{
+			&struct {
+				CAPITALIZED string
+			}{
+				CAPITALIZED: "foo",
+			},
+		},
+	},
 }
 
 func TestUnpackProperties(t *testing.T) {


### PR DESCRIPTION
Soong config variables may propagate an uppercase name from Make.
Blueprint properties have traditionally been all lowercase, and
using an uppercase property struct field name resulted in a strange
Blueprint property name with the first rune lowercase and the
remaining runes uppercase.

Update the rules for proptools.PropertyNameForField to not lowercase
the first rune if the field name has mulitple runes and is not all
uppercase.

Fixes: 148865218
Test: proptools_test.go
Change-Id: I8de2f65ffb00e5a8ce0aea0caf09f5859315f6b8