### PR TITLE
Fix PropertyNameForField for X86.

### DIFF
--- a/proptools/proptools.go
+++ b/proptools/proptools.go
@@ -24,15 +24,16 @@ import (
 // PropertyNameForField converts the name of a field in property struct to the property name that
 // might appear in a Blueprints file.  Since the property struct fields must always be exported
 // to be accessed with reflection and the canonical Blueprints style is lowercased names, it
-// lower cases the first rune in the field name unless the field name contains multiple runes none
-// of which are lowercase, in which case it returns the field name as-is.
+// lower cases the first rune in the field name unless the field name contains an uppercase rune
+// after the first rune (which is always uppercase), and no lowercase runes.
 func PropertyNameForField(fieldName string) string {
 	r, size := utf8.DecodeRuneInString(fieldName)
 	propertyName := string(unicode.ToLower(r))
 	if size == len(fieldName) {
 		return propertyName
 	}
-	if strings.IndexFunc(fieldName[size:], unicode.IsLower) == -1 {
+	if strings.IndexFunc(fieldName[size:], unicode.IsLower) == -1 &&
+		strings.IndexFunc(fieldName[size:], unicode.IsUpper) != -1 {
 		return fieldName
 	}
 	if len(fieldName) > size {

--- a/proptools/proptools_test.go
+++ b/proptools/proptools_test.go
@@ -42,6 +42,26 @@ func TestPropertyNameForField(t *testing.T) {
 			input: "StRiNg",
 			want:  "stRiNg",
 		},
+		{
+			name:  "underscore",
+			input: "Under_score",
+			want:  "under_score",
+		},
+		{
+			name:  "uppercase underscore",
+			input: "UNDER_SCORE",
+			want:  "UNDER_SCORE",
+		},
+		{
+			name:  "x86",
+			input: "X86",
+			want:  "x86",
+		},
+		{
+			name:  "x86_64",
+			input: "X86_64",
+			want:  "x86_64",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Field "X86" has no lowercase runes and was being left uppercase.
Change the new PropertyNameForField rules to lowercase the name unless
it has any uppercase rune after the first rune (which is always
uppercase) and no lowercase runes.

Bug: 148865218
Test: proptools_test.go
Change-Id: Ifd1c10fc03f5ae1765d25b3f73dba8fd61c5c956