### PR TITLE
Fix missing dependencies from mutators

### DIFF
--- a/context.go
+++ b/context.go
@@ -2198,7 +2198,7 @@ func (c *Context) runMutator(config interface{}, mutator *mutatorInfo,
 			newVariationsCh <- mctx.newVariations
 		}
 
-		if len(mctx.reverseDeps) > 0 || len(mctx.replace) > 0 || len(mctx.rename) > 0 || len(mctx.newModules) > 0 {
+		if len(mctx.reverseDeps) > 0 || len(mctx.replace) > 0 || len(mctx.rename) > 0 || len(mctx.newModules) > 0 || len(mctx.ninjaFileDeps) > 0 {
 			globalStateCh <- globalStateChange{
 				reverse:    mctx.reverseDeps,
 				replace:    mctx.replace,


### PR DESCRIPTION
Mutators were not propagating the results of ctx.AddNinjaFileDeps.

Test: examine out/soong/build.ninja.d
Fixes: 150689149
Change-Id: Ia1e69ebc9dfa94a05f4ecd9cc2a8691ee63c9dd5