### PR TITLE
Fix bug in buildPropertyMap in previous commit.

### DIFF
--- a/proptools/unpack_test.go
+++ b/proptools/unpack_test.go
@@ -496,21 +496,31 @@ var validUnpackTestCases = []struct {
 			list = ["abc"]
 			string = "def"
 			list_with_variable = [string]
+			struct_value = { name: "foo" }
 			m {
 				s: string,
 				list: list,
 				list2: list_with_variable,
+				structattr: struct_value,
 			}
 		`,
 		output: []interface{}{
 			&struct {
-				S     string
-				List  []string
-				List2 []string
+				S          string
+				List       []string
+				List2      []string
+				Structattr struct {
+					Name string
+				}
 			}{
 				S:     "def",
 				List:  []string{"abc"},
 				List2: []string{"def"},
+				Structattr: struct {
+					Name string
+				}{
+					Name: "foo",
+				},
 			},
 		},
 	},


### PR DESCRIPTION
Property value should be evaluated before property map is populated with
it. Added the test for this case.