### PR TITLE
Set bpmodify usage function

### DIFF
--- a/bpmodify/bpmodify.go
+++ b/bpmodify/bpmodify.go
@@ -36,6 +36,7 @@ func init() {
 	flag.Var(targetedModules, "m", "comma or whitespace separated list of modules on which to operate")
 	flag.Var(addIdents, "a", "comma or whitespace separated list of identifiers to add")
 	flag.Var(removeIdents, "r", "comma or whitespace separated list of identifiers to remove")
+	flag.Usage = usage
 }
 
 var (
@@ -48,9 +49,8 @@ func report(err error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: bpmodify [flags] [path ...]")
+	fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [flags] [path ...]\n", os.Args[0])
 	flag.PrintDefaults()
-	os.Exit(2)
 }
 
 // If in == nil, the source is the contents of the file with the given filename.


### PR DESCRIPTION
golang `flag` package's default FlagSet `flag.CommandLine` calls
`flag.Usage` and `os.Exit(2)` on error to print the usage string.
Set `flag.Usage` to our custom usage function.

Test: m bpmodify; bpmodify -h; bpmodify --help
Change-Id: Ida107b0dbb07c291c3d7ea90eda9147d04a7cd51