### PR TITLE
bpmodify: respect exitCode

### DIFF
--- a/bpmodify/bpmodify.go
+++ b/bpmodify/bpmodify.go
@@ -223,12 +223,13 @@ func walkDir(path string) {
 }
 
 func main() {
+	defer func() { os.Exit(exitCode) }()
+
 	flag.Parse()
 
 	if flag.NArg() == 0 {
 		if *write {
-			fmt.Fprintln(os.Stderr, "error: cannot use -w with standard input")
-			exitCode = 2
+			report(fmt.Errorf("error: cannot use -w with standard input"))
 			return
 		}
 		if err := processFile("<standard input>", os.Stdin, os.Stdout); err != nil {


### PR DESCRIPTION
main() method calls os.Exit(exitCode) upon return, respecting any
exitCode set by the report() method.

Test: bpmodify -w; echo "$?"
Test: bpmodify Android.bp; echo "$?"
Test: # echo command should output "2"
Change-Id: Iaf056301eaba3f249b256ecf0f0d87f8a4df1c58