### PR TITLE
bpmodify: fix os.Exit() shouldn't shadow panic()

### DIFF
--- a/bpmodify/bpmodify.go
+++ b/bpmodify/bpmodify.go
@@ -223,7 +223,12 @@ func walkDir(path string) {
 }
 
 func main() {
-	defer func() { os.Exit(exitCode) }()
+	defer func() {
+		if err := recover(); err != nil {
+			report(fmt.Errorf("error: %s", err))
+		}
+		os.Exit(exitCode)
+	}()
 
 	flag.Parse()
 


### PR DESCRIPTION
The `defer func() { os.Exit() }()` in main() method shadows panic().
Make the exit handler recover() from panic(), log the panic(), and then
gracefully exit.

Test: m bpmodify
Change-Id: Icc89f8fce0b6096489baa0ba0f08c21d1ef623bc