### PR TITLE
WalkDeps - only record module visited when it has been recursed into

### DIFF
--- a/context.go
+++ b/context.go
@@ -2619,8 +2619,8 @@ func (c *Context) walkDeps(topModule *moduleInfo, allowDuplicates bool,
 				}
 				if recurse && !visited[dep.module] {
 					walk(dep.module)
+					visited[dep.module] = true
 				}
-				visited[dep.module] = true
 				if visitUp != nil {
 					visitUp(dep, module)
 				}


### PR DESCRIPTION
Previously, WalkDeps() would record that a module was visited after the
first time it encountered the module irrespective of whether it recursed
into or not. This change moves the recording so it happens only after it
has been recursed into.

Added TestWalkDepsDuplicates_IgnoreFirstPath to test the change. Without
the change the test fails because it does not visit E.

Test refactoring:
* A depsMutator was added instead of relying on blueprintDepsMutator to
  allow different tags to be used for different dependency types.
* Modified barModule and fooModule to support the new depsMutator and
  add support for another type of dependency that is ignored by the
  walking code.
* Extracted walkDependencyGraph() function to reuse common code.