### PR TITLE
Actually write an empty ninja file with --empty-ninja-file

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -183,6 +183,12 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	var f *os.File
 	var buf *bufio.Writer
 
+	if emptyNinjaFile {
+		if err := ioutil.WriteFile(absolutePath(outFile), []byte(nil), outFilePermissions); err != nil {
+			fatalf("error writing empty Ninja file: %s", err)
+		}
+	}
+
 	if stage != StageMain || !emptyNinjaFile {
 		f, err = os.OpenFile(absolutePath(outFile), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, outFilePermissions)
 		if err != nil {


### PR DESCRIPTION
Otherwise we'll re-run the primary builder every time this is used. This triggered my new ninja checks that verify that all commands write their outputs.