### PR TITLE
Always emit rules for tests and add phony to run them

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -333,13 +333,11 @@ func (g *goPackage) GenerateBuildActions(ctx blueprint.ModuleContext) {
 		testSrcs = append(g.properties.TestSrcs, g.properties.Linux.TestSrcs...)
 	}
 
-	if g.config.runGoTests {
-		testArchiveFile := filepath.Join(testRoot(ctx, g.config),
-			filepath.FromSlash(g.properties.PkgPath)+".a")
-		g.testResultFile = buildGoTest(ctx, testRoot(ctx, g.config), testArchiveFile,
-			g.properties.PkgPath, srcs, genSrcs,
-			testSrcs)
-	}
+	testArchiveFile := filepath.Join(testRoot(ctx, g.config),
+		filepath.FromSlash(g.properties.PkgPath)+".a")
+	g.testResultFile = buildGoTest(ctx, testRoot(ctx, g.config), testArchiveFile,
+		g.properties.PkgPath, srcs, genSrcs,
+		testSrcs)
 
 	buildGoPackage(ctx, g.pkgRoot, g.properties.PkgPath, g.archiveFile,
 		srcs, genSrcs)
@@ -436,9 +434,10 @@ func (g *goBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 		testSrcs = append(g.properties.TestSrcs, g.properties.Linux.TestSrcs...)
 	}
 
+	testDeps := buildGoTest(ctx, testRoot(ctx, g.config), testArchiveFile,
+		name, srcs, genSrcs, testSrcs)
 	if g.config.runGoTests {
-		deps = buildGoTest(ctx, testRoot(ctx, g.config), testArchiveFile,
-			name, srcs, genSrcs, testSrcs)
+		deps = append(deps, testDeps...)
 	}
 
 	buildGoPackage(ctx, objDir, "main", archiveFile, srcs, genSrcs)
@@ -451,7 +450,9 @@ func (g *goBinary) GenerateBuildActions(ctx blueprint.ModuleContext) {
 			linkDeps = append(linkDeps, dep.GoPackageTarget())
 			libDir := dep.GoPkgRoot()
 			libDirFlags = append(libDirFlags, "-L "+libDir)
-			deps = append(deps, dep.GoTestTargets()...)
+			if g.config.runGoTests {
+				deps = append(deps, dep.GoTestTargets()...)
+			}
 		})
 
 	linkArgs := map[string]string{}
@@ -635,17 +636,22 @@ func (s *singleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 	var primaryBuilders []*goBinary
 	// blueprintTools contains blueprint go binaries that will be built in StageMain
 	var blueprintTools []string
-	ctx.VisitAllModulesIf(isBootstrapBinaryModule,
-		func(module blueprint.Module) {
-			binaryModule := module.(*goBinary)
-
+	// blueprintTests contains the result files from the tests
+	var blueprintTests []string
+	ctx.VisitAllModules(func(module blueprint.Module) {
+		if binaryModule, ok := module.(*goBinary); ok {
 			if binaryModule.properties.Tool_dir {
 				blueprintTools = append(blueprintTools, binaryModule.InstallPath())
 			}
 			if binaryModule.properties.PrimaryBuilder {
 				primaryBuilders = append(primaryBuilders, binaryModule)
 			}
-		})
+		}
+
+		if packageModule, ok := module.(goPackageProducer); ok {
+			blueprintTests = append(blueprintTests, packageModule.GoTestTargets()...)
+		}
+	})
 
 	var extraSharedFlagArray []string
 	if s.config.runGoTests {
@@ -759,6 +765,14 @@ func (s *singleton) GenerateBuildActions(ctx blueprint.SingletonContext) {
 			Outputs: []string{"blueprint_tools"},
 			Inputs:  blueprintTools,
 		})
+
+		// Add a phony target for running all of the tests
+		ctx.Build(pctx, blueprint.BuildParams{
+			Rule:    blueprint.Phony,
+			Outputs: []string{"blueprint_tests"},
+			Inputs:  blueprintTests,
+		})
+
 	}
 }
 


### PR DESCRIPTION
Emit the rules to build blueprint tests even if runGoTests is not
set, and add a phony rule "blueprint_tests" to run them.  This will
allow Soong to stop running the tests at the beginning of every build
but still run them as part of checkbuild or with a manual
`m blueprint_tests`.

Bug: 156428456
Test: m
Test: m blueprint_tests
Change-Id: If293a0757766d3046e78bf230a1825f15adc68fd