### PR TITLE
Support checking syntax of generated Blueprint files

### DIFF
--- a/context.go
+++ b/context.go
@@ -692,7 +692,7 @@ func (c *Context) ParseFileList(rootDir string, filePaths []string,
 		var scopedModuleFactories map[string]ModuleFactory
 
 		var addModule func(module *moduleInfo) []error
-		addModule = func(module *moduleInfo) ([]error) {
+		addModule = func(module *moduleInfo) []error {
 			// Run any load hooks immediately before it is sent to the moduleCh and is
 			// registered by name. This allows load hooks to set and/or modify any aspect
 			// of the module (including names) using information that is not available when
@@ -716,7 +716,7 @@ func (c *Context) ParseFileList(rootDir string, filePaths []string,
 		for _, def := range file.Defs {
 			switch def := def.(type) {
 			case *parser.Module:
-				module, errs := c.processModuleDef(def, file.Name, scopedModuleFactories)
+				module, errs := processModuleDef(def, file.Name, c.moduleFactories, scopedModuleFactories, c.ignoreUnknownModuleTypes)
 				if len(errs) == 0 && module != nil {
 					errs = addModule(module)
 				}
@@ -1349,7 +1349,7 @@ func (c *Context) prettyPrintGroupVariants(group *moduleGroup) string {
 	return strings.Join(variants, "\n  ")
 }
 
-func (c *Context) newModule(factory ModuleFactory) *moduleInfo {
+func newModule(factory ModuleFactory) *moduleInfo {
 	logicModule, properties := factory()
 
 	module := &moduleInfo{
@@ -1362,15 +1362,15 @@ func (c *Context) newModule(factory ModuleFactory) *moduleInfo {
 	return module
 }
 
-func (c *Context) processModuleDef(moduleDef *parser.Module,
-	relBlueprintsFile string, scopedModuleFactories map[string]ModuleFactory) (*moduleInfo, []error) {
+func processModuleDef(moduleDef *parser.Module,
+	relBlueprintsFile string, moduleFactories, scopedModuleFactories map[string]ModuleFactory, ignoreUnknownModuleTypes bool) (*moduleInfo, []error) {
 
-	factory, ok := c.moduleFactories[moduleDef.Type]
+	factory, ok := moduleFactories[moduleDef.Type]
 	if !ok && scopedModuleFactories != nil {
 		factory, ok = scopedModuleFactories[moduleDef.Type]
 	}
 	if !ok {
-		if c.ignoreUnknownModuleTypes {
+		if ignoreUnknownModuleTypes {
 			return nil, nil
 		}
 
@@ -1382,7 +1382,7 @@ func (c *Context) processModuleDef(moduleDef *parser.Module,
 		}
 	}
 
-	module := c.newModule(factory)
+	module := newModule(factory)
 	module.typeName = moduleDef.Type
 
 	module.relBlueprintsFile = relBlueprintsFile


### PR DESCRIPTION
Adds a CheckBlueprintSyntax(...) method to check the syntax of a
Blueprint file.

Changes processModuleDef and newModule from being method on *Context to
being standalone functions. That ensures that CheckBlueprintSyntax(...)
does not need to take a context and so there is no chance that it can
change its state.