### PR TITLE
Revert changes that broke the build or tests

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -41,10 +41,10 @@ var (
 	traceFile      string
 	runGoTests     bool
 	noGC           bool
+	moduleListFile string
 	emptyNinjaFile bool
 
 	BuildDir      string
-	ModuleListFile string
 	NinjaBuildDir string
 	SrcDir        string
 
@@ -105,9 +105,9 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	}
 
 	SrcDir = filepath.Dir(flag.Arg(0))
-	if ModuleListFile != "" {
-		ctx.SetModuleListFile(ModuleListFile)
-		extraNinjaFileDeps = append(extraNinjaFileDeps, ModuleListFile)
+	if moduleListFile != "" {
+		ctx.SetModuleListFile(moduleListFile)
+		extraNinjaFileDeps = append(extraNinjaFileDeps, moduleListFile)
 	} else {
 		fatalf("-l <moduleListFile> is required and must be nonempty")
 	}
@@ -133,7 +133,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		topLevelBlueprintsFile: flag.Arg(0),
 		emptyNinjaFile:         emptyNinjaFile,
 		runGoTests:             runGoTests,
-		moduleListFile:         ModuleListFile,
+		moduleListFile:         moduleListFile,
 	}
 
 	ctx.RegisterBottomUpMutator("bootstrap_plugin_deps", pluginDeps)


### PR DESCRIPTION
This reverts commit 63085f9e7c138f15f3edec5e38d7c750a346cfe1.

It breaks the blueprint tests, and we aren't use it yet, so revert
it for now.

Change-Id: I1ac81371342285e8d57baf15fe3a223d4140c6cf