### PR TITLE
Update bpdocs to filter nested properties by tags

### DIFF
--- a/bootstrap/bpdoc/bpdoc_test.go
+++ b/bootstrap/bpdoc/bpdoc_test.go
@@ -44,3 +44,34 @@ func TestNestedPropertyStructs(t *testing.T) {
 		}
 	}
 }
+
+func TestAllModules(t *testing.T) {
+	packages, err := AllPackages(pkgFiles, moduleTypeNameFactories, moduleTypeNamePropertyStructs)
+	if err != nil {
+		t.Fatalf("expected no errors, got %s", err)
+	}
+
+	if numPackages := len(packages); numPackages != 1 {
+		t.Fatalf("Expected 1 package, got %q", numPackages)
+	}
+
+	p := packages[0]
+
+	for _, m := range p.ModuleTypes {
+		for _, p := range m.PropertyStructs {
+			noMutatedProperties(t, p.Properties)
+		}
+	}
+
+}
+
+func noMutatedProperties(t *testing.T, properties []Property) {
+	t.Helper()
+
+	for _, p := range properties {
+		if hasTag(p.Tag, "blueprint", "mutated") {
+			t.Errorf("Property %s has `blueprint:\"mutated\" tag but should have been excluded.", p)
+		}
+		noMutatedProperties(t, p.Properties)
+	}
+}

--- a/bootstrap/bpdoc/bpdoc_test.go
+++ b/bootstrap/bpdoc/bpdoc_test.go
@@ -44,3 +44,34 @@ func TestNestedPropertyStructs(t *testing.T) {
 		}
 	}
 }
+
+func TestAllPackages(t *testing.T) {
+	packages, err := AllPackages(pkgFiles, moduleTypeNameFactories, moduleTypeNamePropertyStructs)
+	if err != nil {
+		t.Fatalf("expected no errors, got %s", err)
+	}
+
+	if numPackages := len(packages); numPackages != 1 {
+		t.Fatalf("Expected 1 package, got %q", numPackages)
+	}
+
+	p := packages[0]
+
+	for _, m := range p.ModuleTypes {
+		for _, p := range m.PropertyStructs {
+			noMutatedProperties(t, p.Properties)
+		}
+	}
+
+}
+
+func noMutatedProperties(t *testing.T, properties []Property) {
+	t.Helper()
+
+	for _, p := range properties {
+		if hasTag(p.Tag, "blueprint", "mutated") {
+			t.Errorf("Property %s has `blueprint:\"mutated\" tag but should have been excluded.", p)
+		}
+		noMutatedProperties(t, p.Properties)
+	}
+}

--- a/bootstrap/bpdoc/bpdoc_test.go
+++ b/bootstrap/bpdoc/bpdoc_test.go
@@ -44,34 +44,3 @@ func TestNestedPropertyStructs(t *testing.T) {
 		}
 	}
 }
-
-func TestAllModules(t *testing.T) {
-	packages, err := AllPackages(pkgFiles, moduleTypeNameFactories, moduleTypeNamePropertyStructs)
-	if err != nil {
-		t.Fatalf("expected no errors, got %s", err)
-	}
-
-	if numPackages := len(packages); numPackages != 1 {
-		t.Fatalf("Expected 1 package, got %q", numPackages)
-	}
-
-	p := packages[0]
-
-	for _, m := range p.ModuleTypes {
-		for _, p := range m.PropertyStructs {
-			noMutatedProperties(t, p.Properties)
-		}
-	}
-
-}
-
-func noMutatedProperties(t *testing.T, properties []Property) {
-	t.Helper()
-
-	for _, p := range properties {
-		if hasTag(p.Tag, "blueprint", "mutated") {
-			t.Errorf("Property %s has `blueprint:\"mutated\" tag but should have been excluded.", p)
-		}
-		noMutatedProperties(t, p.Properties)
-	}
-}

--- a/bootstrap/bpdoc/properties.go
+++ b/bootstrap/bpdoc/properties.go
@@ -251,6 +251,7 @@ func filterPropsByTag(props *[]Property, key, value string, exclude bool) {
 	filtered := (*props)[:0]
 	for _, x := range *props {
 		if hasTag(x.Tag, key, value) == !exclude {
+			filterPropsByTag(&x.Properties, key, value, exclude)
 			filtered = append(filtered, x)
 		}
 	}

--- a/bootstrap/bpdoc/properties.go
+++ b/bootstrap/bpdoc/properties.go
@@ -251,6 +251,7 @@ func filterPropsByTag(props *[]Property, key, value string, exclude bool) {
 	filtered := (*props)[:0]
 	for _, x := range *props {
 		if hasTag(x.Tag, key, value) == !exclude {
+			// filterPropsByTag(&x.Properties, key, value, exclude)
 			filtered = append(filtered, x)
 		}
 	}

--- a/bootstrap/bpdoc/properties.go
+++ b/bootstrap/bpdoc/properties.go
@@ -251,7 +251,6 @@ func filterPropsByTag(props *[]Property, key, value string, exclude bool) {
 	filtered := (*props)[:0]
 	for _, x := range *props {
 		if hasTag(x.Tag, key, value) == !exclude {
-			// filterPropsByTag(&x.Properties, key, value, exclude)
 			filtered = append(filtered, x)
 		}
 	}

--- a/bootstrap/bpdoc/properties_test.go
+++ b/bootstrap/bpdoc/properties_test.go
@@ -28,11 +28,8 @@ func TestExcludeByTag(t *testing.T) {
 
 	ps.ExcludeByTag("tag1", "a")
 
-	expected := []string{"c"}
-	actual := []string{}
-	for _, p := range ps.Properties {
-		actual = append(actual, p.Name)
-	}
+	expected := []string{"c", "d", "g"}
+	actual := actualProperties(t, ps.Properties)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("unexpected ExcludeByTag result, expected: %q, actual: %q", expected, actual)
 	}
@@ -47,12 +44,20 @@ func TestIncludeByTag(t *testing.T) {
 
 	ps.IncludeByTag("tag1", "c")
 
-	expected := []string{"b", "c"}
-	actual := []string{}
-	for _, p := range ps.Properties {
-		actual = append(actual, p.Name)
-	}
+	expected := []string{"b", "c", "d", "f", "g"}
+	actual := actualProperties(t, ps.Properties)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("unexpected IncludeByTag result, expected: %q, actual: %q", expected, actual)
 	}
+}
+
+func actualProperties(t *testing.T, props []Property) []string {
+	t.Helper()
+
+	actual := []string{}
+	for _, p := range props {
+		actual = append(actual, p.Name)
+		actual = append(actual, actualProperties(t, p.Properties)...)
+	}
+	return actual
 }

--- a/bootstrap/bpdoc/properties_test.go
+++ b/bootstrap/bpdoc/properties_test.go
@@ -28,8 +28,11 @@ func TestExcludeByTag(t *testing.T) {
 
 	ps.ExcludeByTag("tag1", "a")
 
-	expected := []string{"c", "d", "g"}
-	actual := actualProperties(t, ps.Properties)
+	expected := []string{"c"}
+	actual := []string{}
+	for _, p := range ps.Properties {
+		actual = append(actual, p.Name)
+	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("unexpected ExcludeByTag result, expected: %q, actual: %q", expected, actual)
 	}
@@ -44,20 +47,12 @@ func TestIncludeByTag(t *testing.T) {
 
 	ps.IncludeByTag("tag1", "c")
 
-	expected := []string{"b", "c", "d", "f", "g"}
-	actual := actualProperties(t, ps.Properties)
+	expected := []string{"b", "c"}
+	actual := []string{}
+	for _, p := range ps.Properties {
+		actual = append(actual, p.Name)
+	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("unexpected IncludeByTag result, expected: %q, actual: %q", expected, actual)
 	}
-}
-
-func actualProperties(t *testing.T, props []Property) []string {
-	t.Helper()
-
-	actual := []string{}
-	for _, p := range props {
-		actual = append(actual, p.Name)
-		actual = append(actual, actualProperties(t, p.Properties)...)
-	}
-	return actual
 }

--- a/bootstrap/bpdoc/reader_test.go
+++ b/bootstrap/bpdoc/reader_test.go
@@ -16,7 +16,6 @@
 package bpdoc
 
 import (
-	"html/template"
 	"reflect"
 	"runtime"
 	"testing"
@@ -24,27 +23,9 @@ import (
 	"github.com/google/blueprint"
 )
 
-type factoryFn func() (blueprint.Module, []interface{})
-
 // foo docs.
 func fooFactory() (blueprint.Module, []interface{}) {
 	return nil, []interface{}{&props{}}
-}
-
-// bar docs.
-func barFactory() (blueprint.Module, []interface{}) {
-	return nil, []interface{}{&complexProps{}}
-}
-
-// for bpdoc_test.go
-type complexProps struct {
-	A         string
-	B_mutated string `blueprint:"mutated"`
-
-	Nested struct {
-		C         string
-		D_mutated string `blueprint:"mutated"`
-	}
 }
 
 // props docs.
@@ -58,18 +39,10 @@ type tagTestProps struct {
 	A string `tag1:"a,b" tag2:"c"`
 	B string `tag1:"a,c"`
 	C string `tag1:"b,c"`
-
-	D struct {
-		E string `tag1:"a,b" tag2:"c"`
-		F string `tag1:"a,c"`
-		G string `tag1:"b,c"`
-	} `tag1:"b,c"`
 }
 
 var pkgPath string
 var pkgFiles map[string][]string
-var moduleTypeNameFactories map[string]reflect.Value
-var moduleTypeNamePropertyStructs map[string][]interface{}
 
 func init() {
 	pc, filename, _, _ := runtime.Caller(0)
@@ -84,34 +57,21 @@ func init() {
 	pkgFiles = map[string][]string{
 		pkgPath: {filename},
 	}
-
-	factories := map[string]factoryFn{"foo": fooFactory, "bar": barFactory}
-
-	moduleTypeNameFactories = make(map[string]reflect.Value, len(factories))
-	moduleTypeNamePropertyStructs = make(map[string][]interface{}, len(factories))
-	for name, factory := range factories {
-		moduleTypeNameFactories[name] = reflect.ValueOf(factory)
-		_, structs := factory()
-		moduleTypeNamePropertyStructs[name] = structs
-	}
 }
 
 func TestModuleTypeDocs(t *testing.T) {
 	r := NewReader(pkgFiles)
-	for m := range moduleTypeNameFactories {
-		mt, err := r.ModuleType(m+"_module", moduleTypeNameFactories[m])
-		if err != nil {
-			t.Fatal(err)
-		}
+	mt, err := r.ModuleType("foo_module", reflect.ValueOf(fooFactory))
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		expectedText := template.HTML(m + " docs.\n\n")
-		if mt.Text != expectedText {
-			t.Errorf("unexpected docs %q", mt.Text)
-		}
+	if mt.Text != "foo docs.\n\n" {
+		t.Errorf("unexpected docs %q", mt.Text)
+	}
 
-		if mt.PkgPath != pkgPath {
-			t.Errorf("expected pkgpath %q, got %q", pkgPath, mt.PkgPath)
-		}
+	if mt.PkgPath != pkgPath {
+		t.Errorf("expected pkgpath %q, got %q", pkgPath, mt.PkgPath)
 	}
 }
 


### PR DESCRIPTION
Prior to this change nested properties tagged with `blueprint:"mutated"`
are erroneously included in documentation, this corrects that behavior
and adds testing to verify.