### PR TITLE
Add CreateAliasVariation

### DIFF
--- a/context.go
+++ b/context.go
@@ -159,10 +159,8 @@ type localBuildActions struct {
 }
 
 type moduleAlias struct {
-	variantName       string
-	variant           variationMap
-	dependencyVariant variationMap
-	target            *moduleInfo
+	variant variant
+	target  *moduleInfo
 }
 
 type moduleGroup struct {
@@ -184,9 +182,7 @@ type moduleInfo struct {
 	propertyPos       map[string]scanner.Position
 	createdBy         *moduleInfo
 
-	variantName       string
-	variant           variationMap
-	dependencyVariant variationMap
+	variant variant
 
 	logicModule Module
 	group       *moduleGroup
@@ -212,6 +208,12 @@ type moduleInfo struct {
 	actionDefs localBuildActions
 }
 
+type variant struct {
+	name                 string
+	variations           variationMap
+	dependencyVariations variationMap
+}
+
 type depInfo struct {
 	module *moduleInfo
 	tag    DependencyTag
@@ -232,8 +234,8 @@ func (module *moduleInfo) Name() string {
 
 func (module *moduleInfo) String() string {
 	s := fmt.Sprintf("module %q", module.Name())
-	if module.variantName != "" {
-		s += fmt.Sprintf(" variant %q", module.variantName)
+	if module.variant.name != "" {
+		s += fmt.Sprintf(" variant %q", module.variant.name)
 	}
 	if module.createdBy != nil {
 		s += fmt.Sprintf(" (created by %s)", module.createdBy)
@@ -1224,8 +1226,37 @@ func (c *Context) cloneLogicModule(origModule *moduleInfo) (Module, []interface{
 	return newLogicModule, newProperties
 }
 
+func newVariant(module *moduleInfo, mutatorName string, variationName string,
+	local bool) variant {
+
+	newVariantName := module.variant.name
+	if variationName != "" {
+		if newVariantName == "" {
+			newVariantName = variationName
+		} else {
+			newVariantName += "_" + variationName
+		}
+	}
+
+	newVariations := module.variant.variations.clone()
+	if newVariations == nil {
+		newVariations = make(variationMap)
+	}
+	newVariations[mutatorName] = variationName
+
+	newDependencyVariations := module.variant.dependencyVariations.clone()
+	if !local {
+		if newDependencyVariations == nil {
+			newDependencyVariations = make(variationMap)
+		}
+		newDependencyVariations[mutatorName] = variationName
+	}
+
+	return variant{newVariantName, newVariations, newDependencyVariations}
+}
+
 func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
-	defaultVariationName *string, variationNames []string) ([]*moduleInfo, []error) {
+	defaultVariationName *string, variationNames []string, local bool) ([]*moduleInfo, []error) {
 
 	if len(variationNames) == 0 {
 		panic(fmt.Errorf("mutator %q passed zero-length variation list for module %q",
@@ -1249,27 +1280,12 @@ func (c *Context) createVariations(origModule *moduleInfo, mutatorName string,
 			newLogicModule, newProperties = c.cloneLogicModule(origModule)
 		}
 
-		newVariant := origModule.variant.clone()
-		if newVariant == nil {
-			newVariant = make(variationMap)
-		}
-		newVariant[mutatorName] = variationName
-
 		m := *origModule
 		newModule := &m
 		newModule.directDeps = append([]depInfo{}, origModule.directDeps...)
 		newModule.logicModule = newLogicModule
-		newModule.variant = newVariant
-		newModule.dependencyVariant = origModule.dependencyVariant.clone()
+		newModule.variant = newVariant(origModule, mutatorName, variationName, local)
 		newModule.properties = newProperties
-
-		if variationName != "" {
-			if newModule.variantName == "" {
-				newModule.variantName = variationName
-			} else {
-				newModule.variantName += "_" + variationName
-			}
-		}
 
 		newModules = append(newModules, newModule)
 
@@ -1296,7 +1312,7 @@ func (c *Context) convertDepsToVariation(module *moduleInfo,
 		if dep.module.logicModule == nil {
 			var newDep *moduleInfo
 			for _, m := range dep.module.splitModules {
-				if m.variant[mutatorName] == variationName {
+				if m.variant.variations[mutatorName] == variationName {
 					newDep = m
 					break
 				}
@@ -1304,7 +1320,7 @@ func (c *Context) convertDepsToVariation(module *moduleInfo,
 			if newDep == nil && defaultVariationName != nil {
 				// give it a second chance; match with defaultVariationName
 				for _, m := range dep.module.splitModules {
-					if m.variant[mutatorName] == *defaultVariationName {
+					if m.variant.variations[mutatorName] == *defaultVariationName {
 						newDep = m
 						break
 					}
@@ -1325,10 +1341,10 @@ func (c *Context) convertDepsToVariation(module *moduleInfo,
 	return errs
 }
 
-func (c *Context) prettyPrintVariant(variant variationMap) string {
-	names := make([]string, 0, len(variant))
+func (c *Context) prettyPrintVariant(variations variationMap) string {
+	names := make([]string, 0, len(variations))
 	for _, m := range c.variantMutatorNames {
-		if v, ok := variant[m]; ok {
+		if v, ok := variations[m]; ok {
 			names = append(names, m+":"+v)
 		}
 	}
@@ -1339,11 +1355,11 @@ func (c *Context) prettyPrintVariant(variant variationMap) string {
 func (c *Context) prettyPrintGroupVariants(group *moduleGroup) string {
 	var variants []string
 	for _, mod := range group.modules {
-		variants = append(variants, c.prettyPrintVariant(mod.variant))
+		variants = append(variants, c.prettyPrintVariant(mod.variant.variations))
 	}
 	for _, mod := range group.aliases {
-		variants = append(variants, c.prettyPrintVariant(mod.variant)+
-			"(alias to "+c.prettyPrintVariant(mod.target.variant)+")")
+		variants = append(variants, c.prettyPrintVariant(mod.variant.variations)+
+			"(alias to "+c.prettyPrintVariant(mod.target.variant.variations)+")")
 	}
 	sort.Strings(variants)
 	return strings.Join(variants, "\n  ")
@@ -1518,18 +1534,18 @@ func (c *Context) findMatchingVariant(module *moduleInfo, possible *moduleGroup,
 		if !reverse {
 			// For forward dependency, ignore local variants by matching against
 			// dependencyVariant which doesn't have the local variants
-			variantToMatch = module.dependencyVariant
+			variantToMatch = module.variant.dependencyVariations
 		} else {
 			// For reverse dependency, use all the variants
-			variantToMatch = module.variant
+			variantToMatch = module.variant.variations
 		}
 		for _, m := range possible.modules {
-			if m.variant.equal(variantToMatch) {
+			if m.variant.variations.equal(variantToMatch) {
 				return m
 			}
 		}
 		for _, m := range possible.aliases {
-			if m.variant.equal(variantToMatch) {
+			if m.variant.variations.equal(variantToMatch) {
 				return m.target
 			}
 		}
@@ -1563,13 +1579,13 @@ func (c *Context) addDependency(module *moduleInfo, tag DependencyTag, depName s
 
 	if c.allowMissingDependencies {
 		// Allow missing variants.
-		return c.discoveredMissingDependencies(module, depName+c.prettyPrintVariant(module.dependencyVariant))
+		return c.discoveredMissingDependencies(module, depName+c.prettyPrintVariant(module.variant.dependencyVariations))
 	}
 
 	return []error{&BlueprintError{
 		Err: fmt.Errorf("dependency %q of %q missing variant:\n  %s\navailable variants:\n  %s",
 			depName, module.Name(),
-			c.prettyPrintVariant(module.dependencyVariant),
+			c.prettyPrintVariant(module.variant.dependencyVariations),
 			c.prettyPrintGroupVariants(possibleDeps)),
 		Pos: module.pos,
 	}}
@@ -1598,20 +1614,20 @@ func (c *Context) findReverseDependency(module *moduleInfo, destName string) (*m
 
 	if c.allowMissingDependencies {
 		// Allow missing variants.
-		return module, c.discoveredMissingDependencies(module, destName+c.prettyPrintVariant(module.dependencyVariant))
+		return module, c.discoveredMissingDependencies(module, destName+c.prettyPrintVariant(module.variant.dependencyVariations))
 	}
 
 	return nil, []error{&BlueprintError{
 		Err: fmt.Errorf("reverse dependency %q of %q missing variant:\n  %s\navailable variants:\n  %s",
 			destName, module.Name(),
-			c.prettyPrintVariant(module.dependencyVariant),
+			c.prettyPrintVariant(module.variant.dependencyVariations),
 			c.prettyPrintGroupVariants(possibleDeps)),
 		Pos: module.pos,
 	}}
 }
 
 func (c *Context) findVariant(module *moduleInfo, possibleDeps *moduleGroup, variations []Variation, far bool, reverse bool) (*moduleInfo, variationMap) {
-	// We can't just append variant.Variant to module.dependencyVariants.variantName and
+	// We can't just append variant.Variant to module.dependencyVariant.variantName and
 	// compare the strings because the result won't be in mutator registration order.
 	// Create a new map instead, and then deep compare the maps.
 	var newVariant variationMap
@@ -1619,10 +1635,10 @@ func (c *Context) findVariant(module *moduleInfo, possibleDeps *moduleGroup, var
 		if !reverse {
 			// For forward dependency, ignore local variants by matching against
 			// dependencyVariant which doesn't have the local variants
-			newVariant = module.dependencyVariant.clone()
+			newVariant = module.variant.dependencyVariations.clone()
 		} else {
 			// For reverse dependency, use all the variants
-			newVariant = module.variant.clone()
+			newVariant = module.variant.variations.clone()
 		}
 	}
 	for _, v := range variations {
@@ -1642,7 +1658,7 @@ func (c *Context) findVariant(module *moduleInfo, possibleDeps *moduleGroup, var
 
 	var foundDep *moduleInfo
 	for _, m := range possibleDeps.modules {
-		if check(m.variant) {
+		if check(m.variant.variations) {
 			foundDep = m
 			break
 		}
@@ -1650,7 +1666,7 @@ func (c *Context) findVariant(module *moduleInfo, possibleDeps *moduleGroup, var
 
 	if foundDep == nil {
 		for _, m := range possibleDeps.aliases {
-			if check(m.variant) {
+			if check(m.variant.variations) {
 				foundDep = m.target
 				break
 			}
@@ -2301,10 +2317,8 @@ func (c *Context) runMutator(config interface{}, mutator *mutatorInfo,
 			// Create any new aliases.
 			if module.aliasTarget != nil {
 				group.aliases = append(group.aliases, &moduleAlias{
-					variantName:       module.variantName,
-					variant:           module.variant,
-					dependencyVariant: module.dependencyVariant,
-					target:            module.aliasTarget,
+					variant: module.variant,
+					target:  module.aliasTarget,
 				})
 			}
 
@@ -2461,7 +2475,7 @@ func (c *Context) generateModuleBuildActions(config interface{},
 		uniqueName := c.nameInterface.UniqueName(newNamespaceContext(module), module.group.name)
 		sanitizedName := toNinjaName(uniqueName)
 
-		prefix := moduleNamespacePrefix(sanitizedName + "_" + module.variantName)
+		prefix := moduleNamespacePrefix(sanitizedName + "_" + module.variant.name)
 
 		// The parent scope of the moduleContext's local scope gets overridden to be that of the
 		// calling Go package on a per-call basis.  Since the initial parent scope doesn't matter we
@@ -2675,13 +2689,13 @@ func (c *Context) moduleMatchingVariant(module *moduleInfo, name string) *module
 	}
 
 	for _, m := range group.modules {
-		if module.variantName == m.variantName {
+		if module.variant.name == m.variant.name {
 			return m
 		}
 	}
 
 	for _, m := range group.aliases {
-		if module.variantName == m.variantName {
+		if module.variant.name == m.variant.name {
 			return m.target
 		}
 	}
@@ -3053,7 +3067,7 @@ func (c *Context) ModuleDir(logicModule Module) string {
 
 func (c *Context) ModuleSubDir(logicModule Module) string {
 	module := c.moduleInfo[logicModule]
-	return module.variantName
+	return module.variant.name
 }
 
 func (c *Context) ModuleType(logicModule Module) string {
@@ -3499,8 +3513,8 @@ func (s depSorter) Less(i, j int) bool {
 	iName := s[i].module.Name()
 	jName := s[j].module.Name()
 	if iName == jName {
-		iName = s[i].module.variantName
-		jName = s[j].module.variantName
+		iName = s[i].module.variant.name
+		jName = s[j].module.variant.name
 	}
 	return iName < jName
 }
@@ -3524,8 +3538,8 @@ func (s moduleSorter) Less(i, j int) bool {
 	iName := s.nameInterface.UniqueName(newNamespaceContext(iMod), iMod.group.name)
 	jName := s.nameInterface.UniqueName(newNamespaceContext(jMod), jMod.group.name)
 	if iName == jName {
-		iName = s.modules[i].variantName
-		jName = s.modules[j].variantName
+		iName = s.modules[i].variant.name
+		jName = s.modules[j].variant.name
 	}
 
 	if iName == jName {
@@ -3576,7 +3590,7 @@ func (c *Context) writeAllModuleActions(nw *ninjaWriter) error {
 			"typeName":  module.typeName,
 			"goFactory": factoryName,
 			"pos":       relPos,
-			"variant":   module.variantName,
+			"variant":   module.variant.name,
 		}
 		err = headerTemplate.Execute(buf, infoMap)
 		if err != nil {

--- a/module_ctx_test.go
+++ b/module_ctx_test.go
@@ -32,10 +32,19 @@ func newModuleCtxTestModule() (Module, []interface{}) {
 func (f *moduleCtxTestModule) GenerateBuildActions(ModuleContext) {
 }
 
-func noCreateAliasMutator(name string) func(ctx BottomUpMutatorContext) {
+func noAliasMutator(name string) func(ctx BottomUpMutatorContext) {
 	return func(ctx BottomUpMutatorContext) {
 		if ctx.ModuleName() == name {
 			ctx.CreateVariations("a", "b")
+		}
+	}
+}
+
+func aliasMutator(name string) func(ctx BottomUpMutatorContext) {
+	return func(ctx BottomUpMutatorContext) {
+		if ctx.ModuleName() == name {
+			ctx.CreateVariations("a", "b")
+			ctx.AliasVariation("b")
 		}
 	}
 }
@@ -44,7 +53,9 @@ func createAliasMutator(name string) func(ctx BottomUpMutatorContext) {
 	return func(ctx BottomUpMutatorContext) {
 		if ctx.ModuleName() == name {
 			ctx.CreateVariations("a", "b")
-			ctx.AliasVariation("b")
+			ctx.CreateAliasVariation("c", "a")
+			ctx.CreateAliasVariation("d", "b")
+			ctx.CreateAliasVariation("e", "a")
 		}
 	}
 }
@@ -57,7 +68,7 @@ func addVariantDepsMutator(variants []Variation, tag DependencyTag, from, to str
 	}
 }
 
-func TestAliases(t *testing.T) {
+func TestAliasVariation(t *testing.T) {
 	runWithFailures := func(ctx *Context, expectedErr string) {
 		t.Helper()
 		bp := `
@@ -115,7 +126,7 @@ func TestAliases(t *testing.T) {
 		// Tests a dependency from "foo" to "bar" variant "b" through alias "".
 		ctx := NewContext()
 		ctx.RegisterModuleType("test", newModuleCtxTestModule)
-		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("1", aliasMutator("bar"))
 		ctx.RegisterBottomUpMutator("2", addVariantDepsMutator(nil, nil, "foo", "bar"))
 
 		run(ctx)
@@ -138,8 +149,8 @@ func TestAliases(t *testing.T) {
 		// Tests a dependency from "foo" to "bar" variant "b_b" through alias "".
 		ctx := NewContext()
 		ctx.RegisterModuleType("test", newModuleCtxTestModule)
-		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
-		ctx.RegisterBottomUpMutator("2", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("1", aliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", aliasMutator("bar"))
 		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator(nil, nil, "foo", "bar"))
 
 		run(ctx)
@@ -162,8 +173,8 @@ func TestAliases(t *testing.T) {
 		// Tests a dependency from "foo" to "bar" variant "a_b" through alias "a".
 		ctx := NewContext()
 		ctx.RegisterModuleType("test", newModuleCtxTestModule)
-		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
-		ctx.RegisterBottomUpMutator("2", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("1", aliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", aliasMutator("bar"))
 		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator([]Variation{{"1", "a"}}, nil, "foo", "bar"))
 
 		run(ctx)
@@ -186,11 +197,126 @@ func TestAliases(t *testing.T) {
 		// Tests a dependency from "foo" to removed "bar" alias "" fails.
 		ctx := NewContext()
 		ctx.RegisterModuleType("test", newModuleCtxTestModule)
-		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
-		ctx.RegisterBottomUpMutator("2", noCreateAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("1", aliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", noAliasMutator("bar"))
 		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator(nil, nil, "foo", "bar"))
 
 		runWithFailures(ctx, `dependency "bar" of "foo" missing variant:`+"\n  \n"+
+			"available variants:"+
+			"\n  1:a, 2:a\n  1:a, 2:b\n  1:b, 2:a\n  1:b, 2:b")
+	})
+}
+
+func TestCreateAliasVariations(t *testing.T) {
+	runWithFailures := func(ctx *Context, expectedErr string) {
+		t.Helper()
+		bp := `
+			test {
+				name: "foo",
+			}
+
+			test {
+				name: "bar",
+			}
+		`
+
+		mockFS := map[string][]byte{
+			"Blueprints": []byte(bp),
+		}
+
+		ctx.MockFileSystem(mockFS)
+
+		_, errs := ctx.ParseFileList(".", []string{"Blueprints"}, nil)
+		if len(errs) > 0 {
+			t.Errorf("unexpected parse errors:")
+			for _, err := range errs {
+				t.Errorf("  %s", err)
+			}
+		}
+
+		_, errs = ctx.ResolveDependencies(nil)
+		if len(errs) > 0 {
+			if expectedErr == "" {
+				t.Errorf("unexpected dep errors:")
+				for _, err := range errs {
+					t.Errorf("  %s", err)
+				}
+			} else {
+				for _, err := range errs {
+					if strings.Contains(err.Error(), expectedErr) {
+						continue
+					} else {
+						t.Errorf("unexpected dep error: %s", err)
+					}
+				}
+			}
+		} else if expectedErr != "" {
+			t.Errorf("missing dep error: %s", expectedErr)
+		}
+	}
+
+	run := func(ctx *Context) {
+		t.Helper()
+		runWithFailures(ctx, "")
+	}
+
+	t.Run("simple", func(t *testing.T) {
+		// Creates a module "bar" with variants "a" and "b" and alias "c" -> "a", "d" -> "b", and "e" -> "a".
+		// Tests a dependency from "foo" to "bar" variant "b" through alias "d".
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", addVariantDepsMutator([]Variation{{"1", "d"}}, nil, "foo", "bar"))
+
+		run(ctx)
+
+		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
+		barB := ctx.moduleGroupFromName("bar", nil).modules[1]
+
+		if g, w := barB.variant.name, "b"; g != w {
+			t.Fatalf("expected bar.modules[1] variant to be %q, got %q", w, g)
+		}
+
+		if g, w := foo.forwardDeps, []*moduleInfo{barB}; !reflect.DeepEqual(g, w) {
+			t.Fatalf("expected foo deps to be %q, got %q", w, g)
+		}
+	})
+
+	t.Run("chained", func(t *testing.T) {
+		// Creates a module "bar" with variants "a_a", "a_b", "b_a" and "b_b" and aliases "c" -> "a_b",
+		// "d" -> "b_b", and "d" -> "a_b".
+		// Tests a dependency from "foo" to "bar" variant "b_b" through alias "d".
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", aliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator([]Variation{{"1", "d"}}, nil, "foo", "bar"))
+
+		run(ctx)
+
+		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
+		barBB := ctx.moduleGroupFromName("bar", nil).modules[3]
+
+		if g, w := barBB.variant.name, "b_b"; g != w {
+			t.Fatalf("expected bar.modules[3] variant to be %q, got %q", w, g)
+		}
+
+		if g, w := foo.forwardDeps, []*moduleInfo{barBB}; !reflect.DeepEqual(g, w) {
+			t.Fatalf("expected foo deps to be %q, got %q", w, g)
+		}
+	})
+
+	t.Run("removed dangling alias", func(t *testing.T) {
+		// Creates a module "bar" with variants "a" and "b" and alias "c" -> "a", "d" -> "b", and "e" -> "a",
+		// then splits the variants into "a_a", "a_b", "b_a" and "b_b" without creating new aliases.
+		// Tests a dependency from "foo" to removed "bar" alias "d" fails.
+		ctx := NewContext()
+		ctx.RegisterModuleType("test", newModuleCtxTestModule)
+		ctx.RegisterBottomUpMutator("1", createAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("2", noAliasMutator("bar"))
+		ctx.RegisterBottomUpMutator("3", addVariantDepsMutator([]Variation{{"1", "d"}}, nil, "foo", "bar"))
+
+		runWithFailures(ctx, `dependency "bar" of "foo" missing variant:`+"\n  1:d\n"+
 			"available variants:"+
 			"\n  1:a, 2:a\n  1:a, 2:b\n  1:b, 2:a\n  1:b, 2:b")
 	})

--- a/module_ctx_test.go
+++ b/module_ctx_test.go
@@ -123,7 +123,7 @@ func TestAliases(t *testing.T) {
 		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
 		barB := ctx.moduleGroupFromName("bar", nil).modules[1]
 
-		if g, w := barB.variantName, "b"; g != w {
+		if g, w := barB.variant.name, "b"; g != w {
 			t.Fatalf("expected bar.modules[1] variant to be %q, got %q", w, g)
 		}
 
@@ -147,7 +147,7 @@ func TestAliases(t *testing.T) {
 		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
 		barBB := ctx.moduleGroupFromName("bar", nil).modules[3]
 
-		if g, w := barBB.variantName, "b_b"; g != w {
+		if g, w := barBB.variant.name, "b_b"; g != w {
 			t.Fatalf("expected bar.modules[3] variant to be %q, got %q", w, g)
 		}
 
@@ -171,7 +171,7 @@ func TestAliases(t *testing.T) {
 		foo := ctx.moduleGroupFromName("foo", nil).modules[0]
 		barAB := ctx.moduleGroupFromName("bar", nil).modules[1]
 
-		if g, w := barAB.variantName, "a_b"; g != w {
+		if g, w := barAB.variant.name, "a_b"; g != w {
 			t.Fatalf("expected bar.modules[1] variant to be %q, got %q", w, g)
 		}
 

--- a/splice_modules_test.go
+++ b/splice_modules_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 var (
-	testModuleA = &moduleInfo{variantName: "testModuleA"}
-	testModuleB = &moduleInfo{variantName: "testModuleB"}
-	testModuleC = &moduleInfo{variantName: "testModuleC"}
-	testModuleD = &moduleInfo{variantName: "testModuleD"}
-	testModuleE = &moduleInfo{variantName: "testModuleE"}
-	testModuleF = &moduleInfo{variantName: "testModuleF"}
+	testModuleA = &moduleInfo{variant: variant{name: "testModuleA"}}
+	testModuleB = &moduleInfo{variant: variant{name: "testModuleB"}}
+	testModuleC = &moduleInfo{variant: variant{name: "testModuleC"}}
+	testModuleD = &moduleInfo{variant: variant{name: "testModuleD"}}
+	testModuleE = &moduleInfo{variant: variant{name: "testModuleE"}}
+	testModuleF = &moduleInfo{variant: variant{name: "testModuleF"}}
 )
 
 var spliceModulesTestCases = []struct {


### PR DESCRIPTION
CreateAliasVariation creates a new variation for the current mutator that is an alias to a variation that was created with CreateVarations by the same mutator.  It is similar to AliasVariation, except that AliasVariation creates an alias from the pre-mutated variant to one of the new variations, while CreateAliasVariation creates an alias from a new post-mutated variation to one of the new variations.

Bug: 164216768
Test: TestCreateAliasVariation
