### PR TITLE
Allow cloned modules to propagate arbitrary data through immutable pointers

### DIFF
--- a/proptools/clone_test.go
+++ b/proptools/clone_test.go
@@ -265,6 +265,27 @@ var clonePropertiesTestCases = []struct {
 			},
 		},
 	},
+	{
+		// Immutable pointer
+		in: &struct {
+			Value string
+			Ptr   *unexportedType `blueprint:"immutable_ptr"`
+			Bool  bool
+		}{
+			Value: "foo",
+			Ptr:   immutablePtr,
+			Bool:  true,
+		},
+		out: &struct {
+			Value string
+			Ptr   *unexportedType `blueprint:"immutable_ptr"`
+			Bool  bool
+		}{
+			Value: "foo",
+			Ptr:   immutablePtr,
+			Bool:  true,
+		},
+	},
 }
 
 type EmbeddedStruct struct {
@@ -272,6 +293,14 @@ type EmbeddedStruct struct {
 	I *int64
 }
 type EmbeddedInterface interface{}
+
+type unexportedType struct {
+	value string
+}
+
+var immutablePtr = &unexportedType{
+	value: "foo",
+}
 
 func TestCloneProperties(t *testing.T) {
 	for _, testCase := range clonePropertiesTestCases {
@@ -492,6 +521,23 @@ var cloneEmptyPropertiesTestCases = []struct {
 				EmbeddedInterface: &struct{ S string }{},
 			},
 		},
+	},
+	{
+		// Immutable pointer
+		in: &struct {
+			Value string
+			Ptr   *unexportedType `blueprint:"immutable_ptr"`
+			Bool  bool
+		}{
+			Value: "foo",
+			Ptr:   immutablePtr,
+			Bool:  true,
+		},
+		out: &struct {
+			Value string
+			Ptr   *unexportedType `blueprint:"immutable_ptr"`
+			Bool  bool
+		}{},
 	},
 }
 

--- a/proptools/extend_test.go
+++ b/proptools/extend_test.go
@@ -782,6 +782,42 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				},
 			},
 		},
+		{
+			// Immutable pointer in in1
+			in1: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+			in2: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: nil,
+			},
+			out: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+		},
+		{
+			// Immutable pointer in in2
+			in1: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: nil,
+			},
+			in2: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+			out: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+		},
 
 		// Errors
 
@@ -936,6 +972,25 @@ func appendPropertiesTestCases() []appendPropertyTestCase {
 				},
 			},
 			err: extendPropertyErrorf("s.i", "unsupported kind int"),
+		},
+		{
+			// Immutable pointer in both
+			in1: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+			in2: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+			out: &struct {
+				Ptr *unexportedType `blueprint:"immutable_ptr"`
+			}{
+				Ptr: immutablePtr,
+			},
+			err: extendPropertyErrorf("ptr", "cannot overwrite immutable pointer"),
 		},
 
 		// Filters
@@ -1451,9 +1506,11 @@ func TestExtendMatchingProperties(t *testing.T) {
 func check(t *testing.T, testType, testString string,
 	got interface{}, err error,
 	expected interface{}, expectedErr error) {
+	t.Helper()
 
 	printedTestCase := false
 	e := func(s string, expected, got interface{}) {
+		t.Helper()
 		if !printedTestCase {
 			t.Errorf("test case %s: %s", testType, testString)
 			printedTestCase = true


### PR DESCRIPTION
Support propagating arbitrary data between cloned modules by blindly
copying pointers tagged with `blueprint:"immutable_ptr"`.  The type
of the property must be a pointer, and the value referenced to must be
nil or never changed, as the value will be shared by multiple modules.
Unfortunately Go has no way to enforce immutability on a type, so this
has to be on the honor system.

Test: TestCloneProperties, TestCloneEmptyProperties, TestZeroProperties, TestExtendProperties
Change-Id: I488de0005c7883e5180b7ffeb2d69e4d1f9aea44