### PR TITLE
Relax check in moduleMatchingVariant

### DIFF
--- a/context.go
+++ b/context.go
@@ -2733,7 +2733,7 @@ func (c *Context) moduleMatchingVariant(module *moduleInfo, name string) *module
 	}
 
 	for _, m := range group.modules {
-		if module.variant.variations.equal(m.moduleOrAliasVariant().variations) {
+		if module.variant.name == m.moduleOrAliasVariant().name {
 			return m.moduleOrAliasTarget()
 		}
 	}


### PR DESCRIPTION
Pull request #317 made the equality check in moduleMatchingVariant
more correct by comparing the variant maps instead of the names.
Using only the names effectively ignores any variation with an
empty name.  Unfortuantely this broke a current user of
ReplaceDependenciesIf.  Go back to the relaxed check for now.

Test: build on a branch with sdk modules
Change-Id: I11016c8df7bd91fd022d04fd3033756f54d7fa0b