### PR TITLE
Correct bug in generating anonymous nested props

### DIFF
--- a/bootstrap/bpdoc/bpdoc.go
+++ b/bootstrap/bpdoc/bpdoc.go
@@ -161,10 +161,11 @@ func assembleModuleTypeInfo(r *Reader, name string, factory reflect.Value,
 				}
 				nestedName += proptools.PropertyNameForField(nested.Name)
 				nestedProp := ps.GetByName(nestedName)
-				if nestedProp == nil {
-					return nil, fmt.Errorf("could not find nested property %q", nestedName)
+				// Anonymous properties may have already been omitted, no need to ensure they are filtered later
+				if nestedProp != nil {
+					// Set property to anonymous to allow future filtering
+					nestedProp.SetAnonymous()
 				}
-				nestedProp.SetAnonymous()
 			}
 		}
 		mt.PropertyStructs = append(mt.PropertyStructs, ps)


### PR DESCRIPTION
Some anonymous nested properties are missing from property structs,
since setting the property to anonymous is to allow future filtering,
there is no issue if we cannot find the struct.

test: go bpdoc tests
test: m soong_docs