### PR TITLE
Improve formatting of some error messages.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1420,7 +1420,7 @@ func (c *Context) prettyPrintVariant(variations variationMap) string {
 		}
 	}
 
-	return strings.Join(names, ", ")
+	return strings.Join(names, ",")
 }
 
 func (c *Context) prettyPrintGroupVariants(group *moduleGroup) string {
@@ -1430,7 +1430,7 @@ func (c *Context) prettyPrintGroupVariants(group *moduleGroup) string {
 			variants = append(variants, c.prettyPrintVariant(mod.variant.variations))
 		} else if alias := moduleOrAlias.alias(); alias != nil {
 			variants = append(variants, c.prettyPrintVariant(alias.variant.variations)+
-				"(alias to "+c.prettyPrintVariant(alias.target.variant.variations)+")")
+				" (alias to "+c.prettyPrintVariant(alias.target.variant.variations)+")")
 		}
 	}
 	return strings.Join(variants, "\n  ")
@@ -1632,7 +1632,7 @@ func (c *Context) addDependency(module *moduleInfo, tag DependencyTag, depName s
 
 	possibleDeps := c.moduleGroupFromName(depName, module.namespace())
 	if possibleDeps == nil {
-		return nil, c.discoveredMissingDependencies(module, depName)
+		return nil, c.discoveredMissingDependencies(module, depName, nil)
 	}
 
 	if m := findExactVariantOrSingle(module, possibleDeps, false); m != nil {
@@ -1643,7 +1643,7 @@ func (c *Context) addDependency(module *moduleInfo, tag DependencyTag, depName s
 
 	if c.allowMissingDependencies {
 		// Allow missing variants.
-		return nil, c.discoveredMissingDependencies(module, depName+c.prettyPrintVariant(module.variant.dependencyVariations))
+		return nil, c.discoveredMissingDependencies(module, depName, module.variant.dependencyVariations)
 	}
 
 	return nil, []error{&BlueprintError{
@@ -1678,7 +1678,7 @@ func (c *Context) findReverseDependency(module *moduleInfo, destName string) (*m
 
 	if c.allowMissingDependencies {
 		// Allow missing variants.
-		return module, c.discoveredMissingDependencies(module, destName+c.prettyPrintVariant(module.variant.dependencyVariations))
+		return module, c.discoveredMissingDependencies(module, destName, module.variant.dependencyVariations)
 	}
 
 	return nil, []error{&BlueprintError{
@@ -1739,7 +1739,7 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 
 	possibleDeps := c.moduleGroupFromName(depName, module.namespace())
 	if possibleDeps == nil {
-		return nil, c.discoveredMissingDependencies(module, depName)
+		return nil, c.discoveredMissingDependencies(module, depName, nil)
 	}
 
 	foundDep, newVariant := findVariant(module, possibleDeps, variations, far, false)
@@ -1747,7 +1747,7 @@ func (c *Context) addVariationDependency(module *moduleInfo, variations []Variat
 	if foundDep == nil {
 		if c.allowMissingDependencies {
 			// Allow missing variants.
-			return nil, c.discoveredMissingDependencies(module, depName+c.prettyPrintVariant(newVariant))
+			return nil, c.discoveredMissingDependencies(module, depName, newVariant)
 		}
 		return nil, []error{&BlueprintError{
 			Err: fmt.Errorf("dependency %q of %q missing variant:\n  %s\navailable variants:\n  %s",
@@ -2986,7 +2986,10 @@ func (c *Context) handleReplacements(replacements []replace) []error {
 	return errs
 }
 
-func (c *Context) discoveredMissingDependencies(module *moduleInfo, depName string) (errs []error) {
+func (c *Context) discoveredMissingDependencies(module *moduleInfo, depName string, depVariations variationMap) (errs []error) {
+	if depVariations != nil {
+		depName = depName + "{" + c.prettyPrintVariant(depVariations) + "}"
+	}
 	if c.allowMissingDependencies {
 		module.missingDeps = append(module.missingDeps, depName)
 		return nil

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -1166,8 +1166,11 @@ func (mctx *mutatorContext) ReplaceDependenciesIf(name string, predicate Replace
 	target := mctx.context.moduleMatchingVariant(mctx.module, name)
 
 	if target == nil {
-		panic(fmt.Errorf("ReplaceDependencies could not find identical variant %q for module %q",
-			mctx.module.variant.name, name))
+		panic(fmt.Errorf("ReplaceDependencies could not find identical variant {%s} for module %s\n"+
+			"available variants:\n  %s",
+			mctx.context.prettyPrintVariant(mctx.module.variant.variations),
+			name,
+			mctx.context.prettyPrintGroupVariants(mctx.context.moduleGroupFromName(name, mctx.module.namespace()))))
 	}
 
 	mctx.replace = append(mctx.replace, replace{target, mctx.module, predicate})

--- a/module_ctx_test.go
+++ b/module_ctx_test.go
@@ -191,7 +191,7 @@ func TestAliasVariation(t *testing.T) {
 
 		runWithFailures(ctx, `dependency "bar" of "foo" missing variant:`+"\n  \n"+
 			"available variants:"+
-			"\n  1:a, 2:a\n  1:a, 2:b\n  1:b, 2:a\n  1:b, 2:b")
+			"\n  1:a,2:a\n  1:a,2:b\n  1:b,2:a\n  1:b,2:b")
 	})
 }
 
@@ -298,7 +298,7 @@ func TestCreateAliasVariations(t *testing.T) {
 
 		runWithFailures(ctx, `dependency "bar" of "foo" missing variant:`+"\n  1:d\n"+
 			"available variants:"+
-			"\n  1:a, 2:a\n  1:a, 2:b\n  1:b, 2:a\n  1:b, 2:b")
+			"\n  1:a,2:a\n  1:a,2:b\n  1:b,2:a\n  1:b,2:b")
 	})
 }
 


### PR DESCRIPTION
In particular the formatting of dependencies with variants which lacked
braces that caused them to float together with the dependency names.

Also add some context to the ReplaceDependenciesIf panic message.

Test: m