### PR TITLE
Create early-exit hook StopBeforeWriteNinja

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -179,6 +179,12 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	}
 	deps = append(deps, extraDeps...)
 
+	if c, ok := config.(ConfigStopBefore); ok {
+		if c.StopBefore() == StopBeforeWriteNinja {
+			return
+		}
+	}
+
 	const outFilePermissions = 0666
 	var out io.Writer
 	var f *os.File

--- a/bootstrap/config.go
+++ b/bootstrap/config.go
@@ -87,6 +87,7 @@ type StopBefore int
 
 const (
 	StopBeforePrepareBuildActions StopBefore = 1
+	StopBeforeWriteNinja          StopBefore = 2
 )
 
 type ConfigStopBefore interface {


### PR DESCRIPTION
This allows exiting bootstrap directly before writing ninja files.
This facilitates shorter runtime on integrations which do processing
which do not require ninja file output.

Test: Manually verified on Soong integration use case which involves
  running bootstrap twice in a single program; stopping before ninja
  output reduces runtime by ~20s, or ~11%.