### PR TITLE
Export Glob method from Context.

### DIFF
--- a/context.go
+++ b/context.go
@@ -1155,7 +1155,7 @@ func (c *Context) findBuildBlueprints(dir string, build []string,
 		var matches []string
 		var err error
 
-		matches, err = c.glob(pattern, nil)
+		matches, err = c.Glob(pattern, nil)
 
 		if err != nil {
 			errs = append(errs, &BlueprintError{
@@ -1197,7 +1197,7 @@ func (c *Context) findSubdirBlueprints(dir string, subdirs []string, subdirsPos 
 		var matches []string
 		var err error
 
-		matches, err = c.glob(pattern, nil)
+		matches, err = c.Glob(pattern, nil)
 
 		if err != nil {
 			errs = append(errs, &BlueprintError{

--- a/glob.go
+++ b/glob.go
@@ -46,7 +46,7 @@ func verifyGlob(fileName, pattern string, excludes []string, g GlobPath) {
 	}
 }
 
-func (c *Context) glob(pattern string, excludes []string) ([]string, error) {
+func (c *Context) Glob(pattern string, excludes []string) ([]string, error) {
 	fileName := globToFileName(pattern, excludes)
 
 	// Try to get existing glob from the stored results

--- a/glob_test.go
+++ b/glob_test.go
@@ -25,7 +25,7 @@ func TestGlobCache(t *testing.T) {
 	})
 
 	// Test a simple glob with no excludes
-	matches, err := ctx.glob("a/*", nil)
+	matches, err := ctx.Glob("a/*", nil)
 	if err != nil {
 		t.Error("unexpected error", err)
 	}
@@ -36,7 +36,7 @@ func TestGlobCache(t *testing.T) {
 	// Test the same glob with an empty excludes array to make sure
 	// excludes=nil does not conflict with excludes=[]string{} in the
 	// cache.
-	matches, err = ctx.glob("a/*", []string{})
+	matches, err = ctx.Glob("a/*", []string{})
 	if err != nil {
 		t.Error("unexpected error", err)
 	}
@@ -45,7 +45,7 @@ func TestGlobCache(t *testing.T) {
 	}
 
 	// Test the same glob with a different excludes array
-	matches, err = ctx.glob("a/*", []string{"a/b"})
+	matches, err = ctx.Glob("a/*", []string{"a/b"})
 	if err != nil {
 		t.Error("unexpected error", err)
 	}

--- a/module_ctx.go
+++ b/module_ctx.go
@@ -457,7 +457,7 @@ func (d *baseModuleContext) Failed() bool {
 
 func (d *baseModuleContext) GlobWithDeps(pattern string,
 	excludes []string) ([]string, error) {
-	return d.context.glob(pattern, excludes)
+	return d.context.Glob(pattern, excludes)
 }
 
 func (d *baseModuleContext) Fs() pathtools.FileSystem {

--- a/singleton_ctx.go
+++ b/singleton_ctx.go
@@ -363,7 +363,7 @@ func (s *singletonContext) AddNinjaFileDeps(deps ...string) {
 
 func (s *singletonContext) GlobWithDeps(pattern string,
 	excludes []string) ([]string, error) {
-	return s.context.glob(pattern, excludes)
+	return s.context.Glob(pattern, excludes)
 }
 
 func (s *singletonContext) Fs() pathtools.FileSystem {


### PR DESCRIPTION
This allows use of globs outside of the context of a Singleton or Module.