### PR TITLE
bpmodify: Do not sort automatically

### DIFF
--- a/bpmodify/bpmodify_test.go
+++ b/bpmodify/bpmodify_test.go
@@ -206,6 +206,48 @@ var testCases = []struct {
 		"",
 		"dep3,dep4",
 	},
+	{
+		`
+		cc_foo {
+			name: "foo",
+			versions: ["1", "2"],
+		}
+		`,
+		`
+		cc_foo {
+			name: "foo",
+			versions: [
+				"1",
+				"2",
+				"10",
+			],
+		}
+		`,
+		"versions",
+		"10",
+		"",
+	},
+	{
+		`
+		cc_foo {
+			name: "foo",
+			deps: ["bar-v1-bar", "bar-v2-bar"],
+		}
+		`,
+		`
+		cc_foo {
+			name: "foo",
+			deps: [
+				"bar-v1-bar",
+				"bar-v2-bar",
+				"bar-v10-bar",
+			],
+		}
+		`,
+		"deps",
+		"bar-v10-bar",
+		"",
+	},
 }
 
 func simplifyModuleDefinition(def string) string {


### PR DESCRIPTION
bpmodify automatically sorts touched list when it is originally sorted.
Even when a user doesn't want this behavior there's no way to avoid
sorting. For example, lists with version numbers.

Now bpmodify sorts the list only if `-s` is given.

Test: bpmodify_test.go
Change-Id: If2fe9bc871a463a47dd3c0b52982b34c9fde05f0