### PR TITLE
Invalidate module group cache if deps are modified

### DIFF
--- a/context.go
+++ b/context.go
@@ -1549,6 +1549,9 @@ func (c *Context) resolveDependencies(ctx context.Context, config interface{}) (
 		if len(errs) > 0 {
 			return
 		}
+		// if any presingletons visited all modules, the cache would be populated by only modules that exist pre-mutators.
+		// we clear the cache so that future calls to visit all modules will be accurate
+		c.clearSortedModuleGroupsCache()
 
 		errs = c.updateDependencies()
 		if len(errs) > 0 {
@@ -3012,6 +3015,10 @@ func (c *Context) moduleGroupFromName(name string, namespace Namespace) *moduleG
 		return group.moduleGroup
 	}
 	return nil
+}
+
+func (c *Context) clearSortedModuleGroupsCache() {
+	c.cachedSortedModuleGroups = nil
 }
 
 func (c *Context) sortedModuleGroups() []*moduleGroup {


### PR DESCRIPTION
PreSingletons run after the blueprints have been parsed and can run         
VisitAllModules; however, this seeds the cache of sorted modules which   
may change after mutators have run. This causes recomputation of the        
cache if any deps have been modified since the last time it was run.    