### PR TITLE
Fix silently ignoring values assigned to map properties

### DIFF
--- a/proptools/unpack.go
+++ b/proptools/unpack.go
@@ -280,6 +280,14 @@ func (ctx *unpackContext) unpackToStruct(namePrefix string, structValue reflect.
 		}
 
 		if isStruct(fieldValue.Type()) {
+			if property.Value.Eval().Type() != parser.MapType {
+				ctx.addError(&UnpackError{
+					fmt.Errorf("can't assign %s value to map property %q",
+						property.Value.Type(), property.Name),
+					property.Value.Pos(),
+				})
+				continue
+			}
 			ctx.unpackToStruct(propertyName, fieldValue)
 			if len(ctx.errs) >= maxUnpackErrors {
 				return

--- a/proptools/unpack.go
+++ b/proptools/unpack.go
@@ -307,8 +307,11 @@ func (ctx *unpackContext) unpackToSlice(
 	sliceName string, property *parser.Property, sliceType reflect.Type) (reflect.Value, bool) {
 	propValueAsList, ok := property.Value.Eval().(*parser.List)
 	if !ok {
-		ctx.addError(fmt.Errorf("%s: can't assign %s value to list property %q",
-			property.Value.Pos(), property.Value.Type(), property.Name))
+		ctx.addError(&UnpackError{
+			fmt.Errorf("can't assign %s value to list property %q",
+				property.Value.Type(), property.Name),
+			property.Value.Pos(),
+		})
 		return reflect.MakeSlice(sliceType, 0, 0), false
 	}
 	exprs := propValueAsList.Values
@@ -387,24 +390,33 @@ func propertyToValue(typ reflect.Type, property *parser.Property) (reflect.Value
 	case reflect.Bool:
 		b, ok := property.Value.Eval().(*parser.Bool)
 		if !ok {
-			return value, fmt.Errorf("%s: can't assign %s value to bool property %q",
-				property.Value.Pos(), property.Value.Type(), property.Name)
+			return value, &UnpackError{
+				fmt.Errorf("can't assign %s value to bool property %q",
+					property.Value.Type(), property.Name),
+				property.Value.Pos(),
+			}
 		}
 		value = reflect.ValueOf(b.Value)
 
 	case reflect.Int64:
 		b, ok := property.Value.Eval().(*parser.Int64)
 		if !ok {
-			return value, fmt.Errorf("%s: can't assign %s value to int64 property %q",
-				property.Value.Pos(), property.Value.Type(), property.Name)
+			return value, &UnpackError{
+				fmt.Errorf("can't assign %s value to int64 property %q",
+					property.Value.Type(), property.Name),
+				property.Value.Pos(),
+			}
 		}
 		value = reflect.ValueOf(b.Value)
 
 	case reflect.String:
 		s, ok := property.Value.Eval().(*parser.String)
 		if !ok {
-			return value, fmt.Errorf("%s: can't assign %s value to string property %q",
-				property.Value.Pos(), property.Value.Type(), property.Name)
+			return value, &UnpackError{
+				fmt.Errorf("can't assign %s value to string property %q",
+					property.Value.Type(), property.Name),
+				property.Value.Pos(),
+			}
 		}
 		value = reflect.ValueOf(s.Value)
 

--- a/proptools/unpack_test.go
+++ b/proptools/unpack_test.go
@@ -24,12 +24,14 @@ import (
 )
 
 var validUnpackTestCases = []struct {
+	name   string
 	input  string
 	output []interface{}
 	empty  []interface{}
 	errs   []error
 }{
 	{
+		name: "blank and unset",
 		input: `
 			m {
 				s: "abc",
@@ -50,6 +52,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "string",
 		input: `
 			m {
 				s: "abc",
@@ -65,6 +68,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "bool",
 		input: `
 			m {
 				isGood: true,
@@ -80,6 +84,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "boolptr",
 		input: `
 			m {
 				isGood: true,
@@ -100,6 +105,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "slice",
 		input: `
 			m {
 				stuff: ["asdf", "jkl;", "qwert",
@@ -123,6 +129,35 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "double nested",
+		input: `
+			m {
+				nested: {
+					nested: {
+						s: "abc",
+					},
+				},
+			}
+		`,
+		output: []interface{}{
+			&struct {
+				Nested struct {
+					Nested struct {
+						S string
+					}
+				}
+			}{
+				Nested: struct{ Nested struct{ S string } }{
+					Nested: struct{ S string }{
+						S: "abc",
+					},
+				},
+			},
+		},
+	},
+
+	{
+		name: "nested",
 		input: `
 			m {
 				nested: {
@@ -144,6 +179,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "nested interface",
 		input: `
 			m {
 				nested: {
@@ -163,6 +199,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "mixed",
 		input: `
 			m {
 				nested: {
@@ -190,6 +227,7 @@ var validUnpackTestCases = []struct {
 	},
 
 	{
+		name: "filter",
 		input: `
 			m {
 				nested: {
@@ -220,6 +258,7 @@ var validUnpackTestCases = []struct {
 
 	// List of maps
 	{
+		name: "list of structs",
 		input: `
 			m {
 				mapslist: [
@@ -254,6 +293,7 @@ var validUnpackTestCases = []struct {
 
 	// List of pointers to structs
 	{
+		name: "list of pointers to structs",
 		input: `
 			m {
 				mapslist: [
@@ -288,6 +328,7 @@ var validUnpackTestCases = []struct {
 
 	// List of lists
 	{
+		name: "list of lists",
 		input: `
 			m {
 				listoflists: [
@@ -310,6 +351,7 @@ var validUnpackTestCases = []struct {
 
 	// Multilevel
 	{
+		name: "multilevel",
 		input: `
 			m {
 				name: "mymodule",
@@ -358,6 +400,7 @@ var validUnpackTestCases = []struct {
 	},
 	// Anonymous struct
 	{
+		name: "embedded struct",
 		input: `
 			m {
 				s: "abc",
@@ -389,6 +432,7 @@ var validUnpackTestCases = []struct {
 
 	// Anonymous interface
 	{
+		name: "embedded interface",
 		input: `
 			m {
 				s: "abc",
@@ -420,6 +464,7 @@ var validUnpackTestCases = []struct {
 
 	// Anonymous struct with name collision
 	{
+		name: "embedded name collision",
 		input: `
 			m {
 				s: "abc",
@@ -456,6 +501,7 @@ var validUnpackTestCases = []struct {
 
 	// Anonymous interface with name collision
 	{
+		name: "embeded interface name collision",
 		input: `
 			m {
 				s: "abc",
@@ -492,6 +538,7 @@ var validUnpackTestCases = []struct {
 
 	// Variables
 	{
+		name: "variables",
 		input: `
 			list = ["abc"]
 			string = "def"
@@ -527,6 +574,7 @@ var validUnpackTestCases = []struct {
 
 	// Multiple property structs
 	{
+		name: "multiple",
 		input: `
 			m {
 				nested: {
@@ -560,6 +608,7 @@ var validUnpackTestCases = []struct {
 
 	// Nil pointer to struct
 	{
+		name: "nil struct pointer",
 		input: `
 			m {
 				nested: {
@@ -589,6 +638,7 @@ var validUnpackTestCases = []struct {
 
 	// Interface containing nil pointer to struct
 	{
+		name: "interface nil struct pointer",
 		input: `
 			m {
 				nested: {
@@ -616,6 +666,7 @@ var validUnpackTestCases = []struct {
 
 	// Factory set properties
 	{
+		name: "factory properties",
 		input: `
 			m {
 				string: "abc",
@@ -675,61 +726,223 @@ var validUnpackTestCases = []struct {
 
 func TestUnpackProperties(t *testing.T) {
 	for _, testCase := range validUnpackTestCases {
-		r := bytes.NewBufferString(testCase.input)
-		file, errs := parser.ParseAndEval("", r, parser.NewScope(nil))
-		if len(errs) != 0 {
-			t.Errorf("test case: %s", testCase.input)
-			t.Errorf("unexpected parse errors:")
-			for _, err := range errs {
-				t.Errorf("  %s", err)
-			}
-			t.FailNow()
-		}
-
-		for _, def := range file.Defs {
-			module, ok := def.(*parser.Module)
-			if !ok {
-				continue
-			}
-
-			var output []interface{}
-			if len(testCase.empty) > 0 {
-				output = testCase.empty
-			} else {
-				for _, p := range testCase.output {
-					output = append(output, CloneEmptyProperties(reflect.ValueOf(p)).Interface())
-				}
-			}
-			_, errs = UnpackProperties(module.Properties, output...)
-			if len(errs) != 0 && len(testCase.errs) == 0 {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := bytes.NewBufferString(testCase.input)
+			file, errs := parser.ParseAndEval("", r, parser.NewScope(nil))
+			if len(errs) != 0 {
 				t.Errorf("test case: %s", testCase.input)
-				t.Errorf("unexpected unpack errors:")
+				t.Errorf("unexpected parse errors:")
 				for _, err := range errs {
 					t.Errorf("  %s", err)
 				}
 				t.FailNow()
-			} else if !reflect.DeepEqual(errs, testCase.errs) {
-				t.Errorf("test case: %s", testCase.input)
-				t.Errorf("incorrect errors:")
-				t.Errorf("  expected: %+v", testCase.errs)
-				t.Errorf("       got: %+v", errs)
 			}
 
-			if len(output) != len(testCase.output) {
-				t.Fatalf("incorrect number of property structs, expected %d got %d",
-					len(testCase.output), len(output))
-			}
+			for _, def := range file.Defs {
+				module, ok := def.(*parser.Module)
+				if !ok {
+					continue
+				}
 
-			for i := range output {
-				got := reflect.ValueOf(output[i]).Interface()
-				if !reflect.DeepEqual(got, testCase.output[i]) {
+				var output []interface{}
+				if len(testCase.empty) > 0 {
+					for _, p := range testCase.empty {
+						output = append(output, CloneProperties(reflect.ValueOf(p)).Interface())
+					}
+				} else {
+					for _, p := range testCase.output {
+						output = append(output, CloneEmptyProperties(reflect.ValueOf(p)).Interface())
+					}
+				}
+
+				_, errs = UnpackProperties(module.Properties, output...)
+				if len(errs) != 0 && len(testCase.errs) == 0 {
 					t.Errorf("test case: %s", testCase.input)
-					t.Errorf("incorrect output:")
-					t.Errorf("  expected: %+v", testCase.output[i])
-					t.Errorf("       got: %+v", got)
+					t.Errorf("unexpected unpack errors:")
+					for _, err := range errs {
+						t.Errorf("  %s", err)
+					}
+					t.FailNow()
+				} else if !reflect.DeepEqual(errs, testCase.errs) {
+					t.Errorf("test case: %s", testCase.input)
+					t.Errorf("incorrect errors:")
+					t.Errorf("  expected: %+v", testCase.errs)
+					t.Errorf("       got: %+v", errs)
+				}
+
+				if len(output) != len(testCase.output) {
+					t.Fatalf("incorrect number of property structs, expected %d got %d",
+						len(testCase.output), len(output))
+				}
+
+				for i := range output {
+					got := reflect.ValueOf(output[i]).Interface()
+					if !reflect.DeepEqual(got, testCase.output[i]) {
+						t.Errorf("test case: %s", testCase.input)
+						t.Errorf("incorrect output:")
+						t.Errorf("  expected: %+v", testCase.output[i])
+						t.Errorf("       got: %+v", got)
+					}
 				}
 			}
-		}
+		})
+	}
+}
+
+func TestUnpackErrors(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output []interface{}
+		errors []string
+	}{
+		{
+			name: "missing",
+			input: `
+				m {
+					missing: true,
+				}
+			`,
+			output: []interface{}{},
+			errors: []string{`<input>:3:13: unrecognized property "missing"`},
+		},
+		{
+			name: "missing nested",
+			input: `
+				m {
+					nested: {
+						missing: true,
+					},
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Nested struct{}
+				}{},
+			},
+			errors: []string{`<input>:4:14: unrecognized property "nested.missing"`},
+		},
+		{
+			name: "mutated",
+			input: `
+				m {
+					mutated: true,
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Mutated bool `blueprint:"mutated"`
+				}{},
+			},
+			errors: []string{`<input>:3:13: mutated field mutated cannot be set in a Blueprint file`},
+		},
+		{
+			name: "nested mutated",
+			input: `
+				m {
+					nested: {
+						mutated: true,
+					},
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Nested struct {
+						Mutated bool `blueprint:"mutated"`
+					}
+				}{},
+			},
+			errors: []string{`<input>:4:14: mutated field nested.mutated cannot be set in a Blueprint file`},
+		},
+		{
+			name: "duplicate",
+			input: `
+				m {
+					exists: true,
+					exists: true,
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Exists bool
+				}{},
+			},
+			errors: []string{
+				`<input>:4:12: property "exists" already defined`,
+				`<input>:3:12: <-- previous definition here`,
+			},
+		},
+		{
+			name: "nested duplicate",
+			input: `
+				m {
+					nested: {
+						exists: true,
+						exists: true,
+					},
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Nested struct {
+						Exists bool
+					}
+				}{},
+			},
+			errors: []string{
+				`<input>:5:13: property "nested.exists" already defined`,
+				`<input>:4:13: <-- previous definition here`,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := bytes.NewBufferString(testCase.input)
+			file, errs := parser.ParseAndEval("", r, parser.NewScope(nil))
+			if len(errs) != 0 {
+				t.Errorf("test case: %s", testCase.input)
+				t.Errorf("unexpected parse errors:")
+				for _, err := range errs {
+					t.Errorf("  %s", err)
+				}
+				t.FailNow()
+			}
+
+			for _, def := range file.Defs {
+				module, ok := def.(*parser.Module)
+				if !ok {
+					continue
+				}
+
+				var output []interface{}
+				for _, p := range testCase.output {
+					output = append(output, CloneEmptyProperties(reflect.ValueOf(p)).Interface())
+				}
+
+				_, errs = UnpackProperties(module.Properties, output...)
+
+				printErrors := false
+				for _, expectedErr := range testCase.errors {
+					foundError := false
+					for _, err := range errs {
+						if err.Error() == expectedErr {
+							foundError = true
+						}
+					}
+					if !foundError {
+						t.Errorf("expected error %s", expectedErr)
+						printErrors = true
+					}
+				}
+				if printErrors {
+					t.Errorf("got errors:")
+					for _, err := range errs {
+						t.Errorf("   %s", err.Error())
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/proptools/unpack_test.go
+++ b/proptools/unpack_test.go
@@ -894,6 +894,74 @@ func TestUnpackErrors(t *testing.T) {
 				`<input>:4:13: <-- previous definition here`,
 			},
 		},
+		{
+			name: "wrong type",
+			input: `
+				m {
+					int: "foo",
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Int *int64
+				}{},
+			},
+			errors: []string{
+				`<input>:3:11: can't assign string value to int64 property "int"`,
+			},
+		},
+		{
+			name: "wrong type for map",
+			input: `
+				m {
+					map: "foo",
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Map struct {
+						S string
+					}
+				}{},
+			},
+			errors: []string{
+				`<input>:3:11: can't assign string value to map property "map"`,
+			},
+		},
+		{
+			name: "wrong type for list",
+			input: `
+				m {
+					list: "foo",
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					List []string
+				}{},
+			},
+			errors: []string{
+				`<input>:3:12: can't assign string value to list property "list"`,
+			},
+		},
+		{
+			name: "wrong type for list of maps",
+			input: `
+				m {
+					map_list: "foo",
+				}
+			`,
+			output: []interface{}{
+				&struct {
+					Map_list []struct {
+						S string
+					}
+				}{},
+			},
+			errors: []string{
+				`<input>:3:16: can't assign string value to list property "map_list"`,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Values assigned to map properties were silently ignored instead of
reported as an error.  Add a check when recursing into structs that
the value is a map.

Fixes: 177706602
Test: m nothing
Test: TestUnpackErrors
