### PR TITLE
Optimize HasTag function

### DIFF
--- a/proptools/tag.go
+++ b/proptools/tag.go
@@ -23,10 +23,17 @@ import (
 // HasTag returns true if a StructField has a tag in the form `name:"foo,value"`.
 func HasTag(field reflect.StructField, name, value string) bool {
 	tag := field.Tag.Get(name)
-	for _, entry := range strings.Split(tag, ",") {
-		if entry == value {
+	for len(tag) > 0 {
+		idx := strings.Index(tag, ",")
+
+		if idx < 0 {
+			return tag == value
+		}
+		if tag[:idx] == value {
 			return true
 		}
+
+		tag = tag[idx+1:]
 	}
 
 	return false

--- a/proptools/tag_test.go
+++ b/proptools/tag_test.go
@@ -19,16 +19,16 @@ import (
 	"testing"
 )
 
-func TestHasTag(t *testing.T) {
-	type testType struct {
-		NoTag       string
-		EmptyTag    string ``
-		OtherTag    string `foo:"bar"`
-		MatchingTag string `name:"value"`
-		ExtraValues string `name:"foo,value,bar"`
-		ExtraTags   string `foo:"bar" name:"value"`
-	}
+type testType struct {
+	NoTag       string
+	EmptyTag    string ``
+	OtherTag    string `foo:"bar"`
+	MatchingTag string `name:"value"`
+	ExtraValues string `name:"foo,value,bar"`
+	ExtraTags   string `foo:"bar" name:"value"`
+}
 
+func TestHasTag(t *testing.T) {
 	tests := []struct {
 		field string
 		want  bool
@@ -63,6 +63,39 @@ func TestHasTag(t *testing.T) {
 			field, _ := reflect.TypeOf(testType{}).FieldByName(test.field)
 			if got := HasTag(field, "name", "value"); got != test.want {
 				t.Errorf(`HasTag(%q, "name", "value") = %v, want %v`, field.Tag, got, test.want)
+			}
+		})
+	}
+}
+
+func BenchmarkHasTag(b *testing.B) {
+	tests := []struct {
+		field string
+	}{
+		{
+			field: "NoTag",
+		},
+		{
+			field: "EmptyTag",
+		},
+		{
+			field: "OtherTag",
+		},
+		{
+			field: "MatchingTag",
+		},
+		{
+			field: "ExtraValues",
+		},
+		{
+			field: "ExtraTags",
+		},
+	}
+	for _, test := range tests {
+		b.Run(test.field, func(b *testing.B) {
+			field, _ := reflect.TypeOf(testType{}).FieldByName(test.field)
+			for i := 0; i < b.N; i++ {
+				HasTag(field, "name", "value")
 			}
 		})
 	}


### PR DESCRIPTION
The commits optimizes HasTag function by avoiding the call to strings.Split that allocates a list of strings.
Here are some results using gprof to measure the speed improvement of this commit:

**Unoptimized HasTag**

```
ROUTINE ======================== github.com/google/blueprint/proptools.HasTag
      80ms      2.47s (flat, cum)  4.47% of Total
         .          .     19:   "reflect"
         .          .     20:   "strings"
         .          .     21:)
         .          .     22:
         .          .     23:// HasTag returns true if a StructField has a tag in the form `name:"foo,value"`.
      40ms       40ms     24:func HasTag(field reflect.StructField, name, value string) bool {
      20ms      430ms     25:   tag := field.Tag.Get(name)
      10ms      1.98s     26:   for _, entry := range strings.Split(tag, ",") {
         .       10ms     27:           if entry == value {
         .          .     28:                   return true
         .          .     29:           }
         .          .     30:   }
         .          .     31:
      10ms       10ms     32:   return false
         .          .     33:}
         .          .     34:
         .          .     35:// PropertyIndexesWithTag returns the indexes of all properties (in the form used by reflect.Value.FieldByIndex) that
         .          .     36:// are tagged with the given key and value, including ones found in embedded structs or pointers to structs.
         .          .     37:func PropertyIndexesWithTag(ps interface{}, key, value string) [][]int {
```

**Optimized HasTag**

```
ROUTINE ======================== github.com/google/blueprint/proptools.HasTag
     140ms      890ms (flat, cum)  1.66% of Total
         .          .     19:   "reflect"
         .          .     20:   "strings"
         .          .     21:)
         .          .     22:
         .          .     23:// HasTag returns true if a StructField has a tag in the form `name:"foo,value"`.
      40ms       40ms     24:func HasTag(field reflect.StructField, name, value string) bool {
      50ms      410ms     25:   tag := field.Tag.Get(name)
      50ms      440ms     26:   return !strings.Contains(value, ",") && hasTagRecursive(tag, value)
         .          .     27:}
         .          .     28:
         .          .     29:func hasTagRecursive(tag, value string) bool {
         .          .     30:   if strings.HasPrefix(tag, value) &&
         .          .     31:           (len(tag) == len(value) || len(tag) > len(value) 
```