### PR TITLE
Remove redundant stat/lstat calls from glob

### DIFF
--- a/pathtools/fs.go
+++ b/pathtools/fs.go
@@ -538,10 +538,22 @@ func listDirsRecursiveRelative(fs FileSystem, name string, follow ShouldFollowSy
 			continue
 		}
 		f = filepath.Join(name, f)
-		if isSymlink, _ := fs.IsSymlink(f); isSymlink && follow == DontFollowSymlinks {
-			continue
+		var info os.FileInfo
+		if follow == DontFollowSymlinks {
+			info, err = fs.Lstat(f)
+			if err != nil {
+				continue
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+		} else {
+			info, err = fs.Stat(f)
+			if err != nil {
+				continue
+			}
 		}
-		if isDir, _ := fs.IsDir(f); isDir {
+		if info.Mode()&os.ModeDir != 0 {
 			dirs = append(dirs, f)
 			subDirs, err := listDirsRecursiveRelative(fs, f, follow, depth)
 			if err != nil {

--- a/pathtools/glob.go
+++ b/pathtools/glob.go
@@ -76,24 +76,18 @@ func startGlob(fs FileSystem, pattern string, excludes []string,
 	}
 
 	for i, match := range matches {
-		isSymlink, err := fs.IsSymlink(match)
+		var info os.FileInfo
+		if follow == DontFollowSymlinks {
+			info, err = fs.Lstat(match)
+		} else {
+			info, err = fs.Stat(match)
+		}
 		if err != nil {
 			return nil, nil, err
 		}
-		if !(isSymlink && follow == DontFollowSymlinks) {
-			isDir, err := fs.IsDir(match)
-			if os.IsNotExist(err) {
-				if isSymlink {
-					return nil, nil, fmt.Errorf("%s: dangling symlink", match)
-				}
-			}
-			if err != nil {
-				return nil, nil, fmt.Errorf("%s: %s", match, err.Error())
-			}
 
-			if isDir {
-				matches[i] = match + "/"
-			}
+		if info.Mode()&os.ModeDir != 0 {
+			matches[i] = match + "/"
 		}
 	}
 


### PR DESCRIPTION
Glob was calling IsSymlink and IsDir on each visited directory entry,
which resulted in an lstat and then a stat call on each.

Instead, use lstat when not following symlinks and use stat when
following symlinks, then use the result to check if the entry is a
directory.

Test: glob_test.go
Change-Id: I83d769e2de64ce8221e952e5204d365aeaf47687