### PR TITLE
Return a copy of glob lists

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -57,7 +57,8 @@ func (c *Context) glob(pattern string, excludes []string) ([]string, error) {
 	if exists {
 		// Glob has already been done, double check it is identical
 		verifyGlob(fileName, pattern, excludes, g)
-		return g.Files, nil
+		// Return a copy so that modifications don't affect the cached value.
+		return append([]string(nil), g.Files...), nil
 	}
 
 	// Get a globbed file list
@@ -76,10 +77,12 @@ func (c *Context) glob(pattern string, excludes []string) ([]string, error) {
 	// Getting the list raced with another goroutine, throw away the results and use theirs
 	if exists {
 		verifyGlob(fileName, pattern, excludes, g)
-		return g.Files, nil
+		// Return a copy so that modifications don't affect the cached value.
+		return append([]string(nil), g.Files...), nil
 	}
 
-	return files, nil
+	// Return a copy so that modifications don't affect the cached value.
+	return append([]string(nil), files...), nil
 }
 
 func (c *Context) Globs() []GlobPath {


### PR DESCRIPTION
Callers to glob methods may do in-place modifications on the returned
list of globs, return a copy instead of the cached value.

Test: m nothing && m nothing
Change-Id: Ic9140d1e1900e8724ba0a484f27786e5c15dea90