### PR TITLE
Optimize ninja writer

### DIFF
--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -186,7 +186,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 	}
 
 	const outFilePermissions = 0666
-	var out io.Writer
+	var out io.StringWriter
 	var f *os.File
 	var buf *bufio.Writer
 
@@ -204,7 +204,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		buf = bufio.NewWriter(f)
 		out = buf
 	} else {
-		out = ioutil.Discard
+		out = ioutil.Discard.(io.StringWriter)
 	}
 
 	if globFile != "" {

--- a/bootstrap/command.go
+++ b/bootstrap/command.go
@@ -201,7 +201,7 @@ func Main(ctx *blueprint.Context, config interface{}, extraNinjaFileDeps ...stri
 		if err != nil {
 			fatalf("error opening Ninja file: %s", err)
 		}
-		buf = bufio.NewWriter(f)
+		buf = bufio.NewWriterSize(f, 16*1024*1024)
 		out = buf
 	} else {
 		out = ioutil.Discard.(io.StringWriter)

--- a/context.go
+++ b/context.go
@@ -3489,7 +3489,7 @@ func (c *Context) SingletonName(singleton Singleton) string {
 // WriteBuildFile writes the Ninja manifeset text for the generated build
 // actions to w.  If this is called before PrepareBuildActions successfully
 // completes then ErrBuildActionsNotReady is returned.
-func (c *Context) WriteBuildFile(w io.Writer) error {
+func (c *Context) WriteBuildFile(w io.StringWriter) error {
 	var err error
 	pprof.Do(c.Context, pprof.Labels("blueprint", "WriteBuildFile"), func(ctx context.Context) {
 		if !c.buildActionsReady {

--- a/context.go
+++ b/context.go
@@ -2309,6 +2309,8 @@ func (c *Context) PrepareBuildActions(config interface{}) (deps []string, errs [
 
 		deps = append(deps, depsPackages...)
 
+		c.memoizeFullNames(c.liveGlobals, pkgNames)
+
 		// This will panic if it finds a problem since it's a programming error.
 		c.checkForVariableReferenceCycles(c.liveGlobals.variables, pkgNames)
 
@@ -3171,6 +3173,21 @@ func (c *Context) makeUniquePackageNames(
 	}
 
 	return pkgNames, deps
+}
+
+// memoizeFullNames stores the full name of each live global variable, rule and pool since each is
+// guaranteed to be used at least twice, once in the definition and once for each usage, and many
+// are used much more than once.
+func (c *Context) memoizeFullNames(liveGlobals *liveTracker, pkgNames map[*packageContext]string) {
+	for v := range liveGlobals.variables {
+		v.memoizeFullName(pkgNames)
+	}
+	for r := range liveGlobals.rules {
+		r.memoizeFullName(pkgNames)
+	}
+	for p := range liveGlobals.pools {
+		p.memoizeFullName(pkgNames)
+	}
 }
 
 func (c *Context) checkForVariableReferenceCycles(

--- a/ninja_defs.go
+++ b/ninja_defs.go
@@ -392,20 +392,20 @@ func (b *buildDef) WriteTo(nw *ninjaWriter, pkgNames map[*packageContext]string)
 	var (
 		comment       = b.Comment
 		rule          = b.Rule.fullName(pkgNames)
-		outputs       = valueList(b.Outputs, pkgNames, outputEscaper)
-		implicitOuts  = valueList(b.ImplicitOutputs, pkgNames, outputEscaper)
-		explicitDeps  = valueList(b.Inputs, pkgNames, inputEscaper)
-		implicitDeps  = valueList(b.Implicits, pkgNames, inputEscaper)
-		orderOnlyDeps = valueList(b.OrderOnly, pkgNames, inputEscaper)
-		validations   = valueList(b.Validations, pkgNames, inputEscaper)
+		outputs       = b.Outputs
+		implicitOuts  = b.ImplicitOutputs
+		explicitDeps  = b.Inputs
+		implicitDeps  = b.Implicits
+		orderOnlyDeps = b.OrderOnly
+		validations   = b.Validations
 	)
 
 	if b.RuleDef != nil {
-		implicitDeps = append(valueList(b.RuleDef.CommandDeps, pkgNames, inputEscaper), implicitDeps...)
-		orderOnlyDeps = append(valueList(b.RuleDef.CommandOrderOnly, pkgNames, inputEscaper), orderOnlyDeps...)
+		implicitDeps = append(b.RuleDef.CommandDeps, implicitDeps...)
+		orderOnlyDeps = append(b.RuleDef.CommandOrderOnly, orderOnlyDeps...)
 	}
 
-	err := nw.Build(comment, rule, outputs, implicitOuts, explicitDeps, implicitDeps, orderOnlyDeps, validations)
+	err := nw.Build(comment, rule, outputs, implicitOuts, explicitDeps, implicitDeps, orderOnlyDeps, validations, pkgNames)
 	if err != nil {
 		return err
 	}
@@ -435,23 +435,13 @@ func (b *buildDef) WriteTo(nw *ninjaWriter, pkgNames map[*packageContext]string)
 	}
 
 	if !b.Optional {
-		err = nw.Default(outputs...)
+		err = nw.Default(pkgNames, outputs...)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nw.BlankLine()
-}
-
-func valueList(list []ninjaString, pkgNames map[*packageContext]string,
-	escaper *strings.Replacer) []string {
-
-	result := make([]string, len(list))
-	for i, ninjaStr := range list {
-		result[i] = ninjaStr.ValueWithEscaper(pkgNames, escaper)
-	}
-	return result
 }
 
 func writeVariables(nw *ninjaWriter, variables map[string]ninjaString,

--- a/ninja_strings.go
+++ b/ninja_strings.go
@@ -17,6 +17,7 @@ package blueprint
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -36,7 +37,7 @@ var (
 
 type ninjaString interface {
 	Value(pkgNames map[*packageContext]string) string
-	ValueWithEscaper(pkgNames map[*packageContext]string, escaper *strings.Replacer) string
+	ValueWithEscaper(w io.StringWriter, pkgNames map[*packageContext]string, escaper *strings.Replacer)
 	Eval(variables map[Variable]ninjaString) (string, error)
 	Variables() []Variable
 }
@@ -284,26 +285,24 @@ func parseNinjaStrings(scope scope, strs []string) ([]ninjaString,
 }
 
 func (n varNinjaString) Value(pkgNames map[*packageContext]string) string {
-	return n.ValueWithEscaper(pkgNames, defaultEscaper)
+	if len(n.strings) == 1 {
+		return defaultEscaper.Replace(n.strings[0])
+	}
+	str := &strings.Builder{}
+	n.ValueWithEscaper(str, pkgNames, defaultEscaper)
+	return str.String()
 }
 
-func (n varNinjaString) ValueWithEscaper(pkgNames map[*packageContext]string,
-	escaper *strings.Replacer) string {
+func (n varNinjaString) ValueWithEscaper(w io.StringWriter, pkgNames map[*packageContext]string,
+	escaper *strings.Replacer) {
 
-	if len(n.strings) == 1 {
-		return escaper.Replace(n.strings[0])
-	}
-
-	str := strings.Builder{}
-	str.WriteString(escaper.Replace(n.strings[0]))
+	w.WriteString(escaper.Replace(n.strings[0]))
 	for i, v := range n.variables {
-		str.WriteString("${")
-		str.WriteString(v.fullName(pkgNames))
-		str.WriteString("}")
-		str.WriteString(escaper.Replace(n.strings[i+1]))
+		w.WriteString("${")
+		w.WriteString(v.fullName(pkgNames))
+		w.WriteString("}")
+		w.WriteString(escaper.Replace(n.strings[i+1]))
 	}
-
-	return str.String()
 }
 
 func (n varNinjaString) Eval(variables map[Variable]ninjaString) (string, error) {
@@ -327,12 +326,12 @@ func (n varNinjaString) Variables() []Variable {
 }
 
 func (l literalNinjaString) Value(pkgNames map[*packageContext]string) string {
-	return l.ValueWithEscaper(pkgNames, defaultEscaper)
+	return defaultEscaper.Replace(string(l))
 }
 
-func (l literalNinjaString) ValueWithEscaper(pkgNames map[*packageContext]string,
-	escaper *strings.Replacer) string {
-	return escaper.Replace(string(l))
+func (l literalNinjaString) ValueWithEscaper(w io.StringWriter, pkgNames map[*packageContext]string,
+	escaper *strings.Replacer) {
+	w.WriteString(escaper.Replace(string(l)))
 }
 
 func (l literalNinjaString) Eval(variables map[Variable]ninjaString) (string, error) {


### PR DESCRIPTION
This stack optimizes Blueprint's ninja writer.  On an internal master branch it reduces the mean soong_build execution time from 91s to 87s (4.4%).