### PR TITLE
Fix ReplaceExtension

### DIFF
--- a/Blueprints
+++ b/Blueprints
@@ -70,6 +70,7 @@ bootstrap_go_package {
     testSrcs: [
         "pathtools/fs_test.go",
         "pathtools/glob_test.go",
+        "pathtools/lists_test.go",
     ],
 }
 

--- a/pathtools/lists.go
+++ b/pathtools/lists.go
@@ -38,10 +38,12 @@ func ReplaceExtensions(paths []string, extension string) []string {
 	return result
 }
 
+// ReplaceExtension changes the file extension. If the file does not have an
+// extension, the new extension is appended.
 func ReplaceExtension(path string, extension string) string {
-	dot := strings.LastIndex(path, ".")
-	if dot == -1 {
-		return path
+	oldExt := filepath.Ext(path)
+	if oldExt != "" {
+		path = strings.TrimSuffix(path, oldExt)
 	}
-	return path[:dot+1] + extension
+	return path + "." + extension
 }

--- a/pathtools/lists_test.go
+++ b/pathtools/lists_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pathtools
+
+import (
+	"testing"
+)
+
+func TestLists_ReplaceExtension(t *testing.T) {
+
+	testCases := []struct {
+		from, ext, to string
+	}{
+		{"1.jpg", "png", "1.png"},
+		{"1", "png", "1.png"},
+		{"1.", "png", "1.png"},
+		{"2.so", "so.1", "2.so.1"},
+		{"/out/.test/1.png", "jpg", "/out/.test/1.jpg"},
+		{"/out/.test/1", "jpg", "/out/.test/1.jpg"},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.from, func(t *testing.T) {
+			got := ReplaceExtension(test.from, test.ext)
+			if got != test.to {
+				t.Errorf("ReplaceExtension(%v, %v) = %v; want: %v", test.from, test.ext, got, test.to)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ReplaceExtension had an unexpected behaviour when the file did not have
an extension. In certain cases, the final path would be severely
trimmed: out/.intermediates/my_file would become out/.new_extension.
Explicitly handle the case by appending the new extension.

Test: Run checkbuild on Android Soong
Change-Id: Ie27a98845894cfaee5af5e2a02d44168c40ed821